### PR TITLE
chore(ci): also upload the preview

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -12,6 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Display node and npm version
+        run: |
+          node --version
+          npm --version
       - name: Install npm modules
         run: npm ci
       - name: Bundle documentation theme
@@ -28,5 +32,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: bonita-documentation-ui-preview
-          path: public/_
+          path: public
           retention-days: 7

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Upload UI bundle
         uses: actions/upload-artifact@v2
         with:
-          name: bonita-documentation-ui-bundle
+          name: ui-bundle-${{github.sha}}
           path: build/ui-bundle.zip
           retention-days: 7
       - name: Build preview
@@ -35,6 +35,6 @@ jobs:
       - name: Upload preview
         uses: actions/upload-artifact@v2
         with:
-          name: bonita-documentation-ui-preview
+          name: ui-preview-${{github.sha}}
           path: public
           retention-days: 7

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -12,6 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
       - name: Display node and npm version
         run: |
           node --version

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -16,10 +16,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - name: Display node and npm version
-        run: |
-          node --version
-          npm --version
       - name: Install npm modules
         run: npm ci
       - name: Bundle documentation theme

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -13,12 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install npm modules
-        run: npm install
+        run: npm ci
       - name: Bundle documentation theme
         run: gulp bundle
-      - name: Upload ui bundle
+      - name: Upload UI bundle
         uses: actions/upload-artifact@v2
         with:
           name: bonita-documentation-ui-bundle
           path: build/ui-bundle.zip
+          retention-days: 7
+      - name: Build preview
+        run: gulp preview:build
+      - name: Upload preview
+        uses: actions/upload-artifact@v2
+        with:
+          name: bonita-documentation-ui-preview
+          path: public/_
           retention-days: 7

--- a/README.adoc
+++ b/README.adoc
@@ -2,8 +2,9 @@
 
 NOTE: Readme in progress
 
-This project produce the UI bundle used by the Bonita documentation website.
-It has been generated using the [Antora default UI](https://gitlab.com/antora/antora-ui-default).
+This project produces the Antora UI bundle used by the https://github.com/bonitasoft/bonitasoft.github.io[bonitasoft.github.io]
+repository to build the Bonita documentation website. +
+It is based on the https://gitlab.com/antora/antora-ui-default[Antora default UI].
 
 == Usage
 
@@ -12,3 +13,8 @@ TODO: how to use the bundle in the antora conf file
 == Development
 
 TODO
+
+A static or live preview of the theme is available, see the xref:docs/modules/ROOT/pages/build-preview-ui.adoc[build-preview-ui]
+documentation.
+
+To build the bundle to be used in the Antora playbook, run `gulp bundle`.


### PR DESCRIPTION
Changes
- Upload the preview to have a quick overview of what changed in the Antora UI bundle
- Have more consistent builds (same as we do in https://github.com/bonitasoft/bonitasoft.github.io)
  - enforce the ubuntu version of the runner
  - run npm ci instead of npm install to ensure we use lock versions for dependencies (see https://docs.npmjs.com/cli/v6/commands/npm-ci)
  - enforce the node version to 12.x to avoid depending on the default installed on the runner and that can change at any time
  - uploaded artifacts have an unique name at each build for a better identification


Warning fixed by this PR

![image](https://user-images.githubusercontent.com/27200110/100993624-ef681480-3555-11eb-8252-2c3dc14bee50.png)

