### PR TITLE
feat: add settings to improve documentation archives generation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,12 @@
 = Bonita Documentation Theme
+:icons: font
+ifdef::env-github[]
+:note-caption: :information_source:
+:tip-caption: :bulb:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 This project produces the Antora UI bundle used by the https://github.com/bonitasoft/bonitasoft.github.io[bonitasoft.github.io]
 repository to build the Bonita documentation website. +

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -3,6 +3,7 @@ site:
   keys:
     nonProduction: false
     hideEditPageLinks: false
+    hideNavbarComponentsList: false
   url: http://localhost:5252
   title: Brand Docs
   homeUrl: &home_url /bonita/7.10/index.html

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -2,6 +2,7 @@ antoraVersion: '1.0.0'
 site:
   keys:
     nonProduction: false
+    hideEditPageLinks: false
   url: http://localhost:5252
   title: Brand Docs
   homeUrl: &home_url /bonita/7.10/index.html

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -33,11 +33,13 @@
           </label>
         </div>
       </div>
+      {{#unless site.keys.hideNavbarComponentsList}}
       {{#each site.components}}
       <div class="navbar-item is-hoverable">
         <a class="navbar-link" href="{{{./latestVersion.url}}}">{{{./title}}}</a>
       </div>
       {{/each}}
+      {{/unless}}
     </div>
 
     <div class="navbar-search" id="search-container">

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -5,9 +5,11 @@
   {{/with}}
   {{> breadcrumbs}}
   {{> page-versions}}
+  {{#unless site.keys.hideEditPageLinks}}
   {{#if (and page.fileUri (not env.CI))}}
   <div class="edit-this-page"><a href="{{page.fileUri}}">Edit this Page</a></div>
   {{else if (and page.editUrl (or env.FORCE_SHOW_EDIT_PAGE_LINK (not page.origin.private)))}}
   <div class="edit-this-page"><a href="{{page.editUrl}}">Edit this Page</a></div>
   {{/if}}
+  {{/unless}}
 </div>


### PR DESCRIPTION
**Will be used by https://github.com/bonitasoft/bonitasoft.github.io/pull/190**

Hide 'edit page links'
We don't want to display such links in documentation archives we want to make
available for download only.
In this case, the documentation content source code is not available locally
so keeping the links is just misleading.

Hide 'components list' in the navbar
For single component version archive, this is not need as we have a single
component. In addition, the link produced for component in this list doesn't
work for local file browsing.
