### PR TITLE
lock video size on mobile

### DIFF
--- a/preview-src/misc.adoc
+++ b/preview-src/misc.adoc
@@ -1,3 +1,11 @@
+= MISC
+
+== Test Video
+
+{empty} +
+
+video::Hl1thnPla7E[youtube, width=640,height=380]
+
 == Test raw admonitions
 
 [NOTE]

--- a/src/stylesheets/doc.scss
+++ b/src/stylesheets/doc.scss
@@ -1160,3 +1160,12 @@
     }
   }
 }
+
+@media screen and (max-width: 768px) {
+  .videoblock {
+    iframe {
+      width: inherit;
+      height: inherit;
+    }
+  }
+}


### PR DESCRIPTION
Custom size can be used on desktop (and will be tested by the contributor), but we must lock it for mobile view else the iframe will take too much space.