### PR TITLE
Update number of hits displayed by the search

### DIFF
--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -24,7 +24,8 @@
     algoliaOptions: {
       // Can't be extracted on a js file because facetFilters are valued by Antora at build time, only on html files!
       'facetFilters': ["version:{{page.version}}", "tags:{{page.component.name}}"],
-      clickAnalytics: true
+      clickAnalytics: true,
+      hitsPerPage: 20
     },
     handleSelected: function (input, event, suggestion, datasetNumber, context) {
       sendClickEvent(lastQueryID, lastQueryHits, suggestion);


### PR DESCRIPTION
- Display 20 hits instead of 5 to ensure that for a given query users have a good chance to find the page they are looking for.

[WWW-982](https://bonitasoft.atlassian.net/browse/WWW-982)