### PR TITLE
chore: only load docsearch resources when search is displayed

### DIFF
--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -1,9 +1,17 @@
 <script async src="{{{uiRootPath}}}/js/vendor/asciinema-player.min.js"></script>
 <script src="{{{uiRootPath}}}/js/vendor/highlight.min.js"></script>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+{{!-- DocSearch only available if the search bar is displayed --}}
+{{#unless site.keys.nonProduction}}
+  {{#unless page.attributes.hide-search-bar }}
+    <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2.6.3/dist/cdn/docsearch.min.js" integrity="sha256-qybEsgf0PGiQS22AmoozPs09oRnSC7Gu7eBu4fbS2Ac=" crossorigin="anonymous"></script>
+  {{/unless}}
+{{/unless}}
 <script>hljs.initHighlightingOnLoad();</script>
 <script src="{{{uiRootPath}}}/js/site.js"></script>
 
+{{!-- DocSearch only available if the search bar is displayed --}}
+{{#unless site.keys.nonProduction}}
+  {{#unless page.attributes.hide-search-bar }}
 <script>
   var ALGOLIA_INSIGHTS_SRC = "https://cdn.jsdelivr.net/npm/search-insights@1.7.1";
 
@@ -43,6 +51,8 @@
     apiKey: '16267f96d135c47df8454efd5b448c9a',
   });
 </script>
+  {{/unless}}
+{{/unless}}
 
 <script>
   // init toggle state

--- a/src/partials/head-styles.hbs
+++ b/src/partials/head-styles.hbs
@@ -1,4 +1,10 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+{{!-- DocSearch only available if the search bar is displayed --}}
+{{#unless site.keys.nonProduction}}
+  {{#unless page.attributes.hide-search-bar }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2.6.3/dist/cdn/docsearch.css" integrity="sha256-tY3FCmL2d8yoJBOVyC2aOxdixg8sLT6CHlDWX/VUJaY=" crossorigin="anonymous">
+  {{/unless}}
+{{/unless}}
+
 <link rel="stylesheet" href="{{{uiRootPath}}}/stylesheets/vendor/asciinema-player.css">
 <link rel="stylesheet" href="{{{uiRootPath}}}/stylesheets/site.css">
 <link id="highlight-style-lnk" rel="stylesheet" href="{{{uiRootPath}}}/stylesheets/vendor/highlight-light.css">


### PR DESCRIPTION
This avoids loading useless resources when the search is not available in the
page. It previously generated a JS error because some HTML element was not
present in the page.

Also use specific version of docsearch resources to improve caching and use SRI.

covers https://github.com/bonitasoft/bonita-documentation-site/issues/235