### PR TITLE
feat: remove the 'isNotApiComponent' handlebars macro

### DIFF
--- a/src/helpers/isNotApiComponent.js
+++ b/src/helpers/isNotApiComponent.js
@@ -1,5 +1,0 @@
-'use strict'
-
-module.exports = (value) => {
-  return value !== 'bonitaAPI'
-}

--- a/src/partials/nav.hbs
+++ b/src/partials/nav.hbs
@@ -1,4 +1,3 @@
-{{#if (isNotApiComponent page.component.name)}}
 <div class="nav-container"{{#if page.component}} data-component="{{page.component.name}}" data-version="{{page.version}}"{{/if}}>
   <aside class="nav">
     <div class="panels">
@@ -7,4 +6,3 @@
     </div>
   </aside>
 </div>
-{{/if}}

--- a/src/partials/toc.hbs
+++ b/src/partials/toc.hbs
@@ -1,5 +1,3 @@
-{{#if (isNotApiComponent page.component.name)}}
 <aside class="toc sidebar" data-title="{{or page.attributes.toctitle 'Contents'}}" data-levels="{{{or page.attributes.toclevels 2}}}">
   <div class="toc-menu"></div>
 </aside>
-{{/if}}


### PR DESCRIPTION
We don't have component using the 'bonitaAPI' component.name. So, there is no
reason for filtering such component in nav and toc.
This seems to be a remaining part of the POC done in 2020: we were trying to
integrate the Bonita API documentation within the site. We don't have such API
in the site for now.