### PR TITLE
feat(table): Improve colors in admonitions with table content

### DIFF
--- a/preview-src/misc.adoc
+++ b/preview-src/misc.adoc
@@ -110,6 +110,36 @@ Allez Grenoble
 +
 . blabla
 
+[NOTE]
+====
+|===
+| OS | Description
+
+| Windaube
+| Oulala
+
+| Macos
+| Pure gold
+
+| Linoux
+| Truc de geek
+|===
+====
+
+[WARNING]
+====
+|===
+| Gens à éviter
+
+| Parisiens
+
+| Bretons
+
+| Sudistes
+
+|===
+====
+
 
 == Test title level **WITH BOLD**
 

--- a/src/stylesheets/doc.scss
+++ b/src/stylesheets/doc.scss
@@ -788,6 +788,26 @@
     strong {
       color: var(--color-admonition-caution-text);
     }
+
+    table.tableblock {
+      td {
+        border-top-color: var(--color-admonition-caution);
+        border-bottom-color: var(--color-admonition-caution);
+      }
+
+      thead th {
+        border-bottom-color: var(--color-admonition-caution);
+      }
+
+      > {
+      :not(thead) {
+          th {
+            border-top-color: var(--color-admonition-caution);
+            border-bottom-color: var(--color-admonition-caution);
+          }
+        }
+      }
+    }
   }
 
   .admonitionblock.important {
@@ -817,6 +837,26 @@
     strong {
       color: var(--color-admonition-important-text);
     }
+
+    table.tableblock {
+      td {
+        border-top-color: var(--color-admonition-important);
+        border-bottom-color: var(--color-admonition-important);
+      }
+
+      thead th {
+        border-bottom-color: var(--color-admonition-important);
+      }
+
+      > {
+      :not(thead) {
+          th {
+            border-top-color: var(--color-admonition-important);
+            border-bottom-color: var(--color-admonition-important);
+          }
+        }
+      }
+    }
   }
 
   .admonitionblock.note {
@@ -845,6 +885,26 @@
 
     strong {
       color: var(--color-admonition-note-text);
+    }
+
+    table.tableblock {
+      td {
+        border-top-color: var(--color-admonition-note);
+        border-bottom-color: var(--color-admonition-note);
+      }
+
+      thead th {
+        border-bottom-color: var(--color-admonition-note);
+      }
+
+      > {
+      :not(thead) {
+          th {
+            border-top-color: var(--color-admonition-note);
+            border-bottom-color: var(--color-admonition-note);
+          }
+        }
+      }
     }
   }
 
@@ -885,6 +945,26 @@
     strong {
       color: var(--color-admonition-tip-text);
     }
+
+    table.tableblock {
+      td {
+        border-top-color: var(--color-admonition-tip);
+        border-bottom-color: var(--color-admonition-tip);
+      }
+
+      thead th {
+        border-bottom-color: var(--color-admonition-tip);
+      }
+
+      > {
+      :not(thead) {
+          th {
+            border-top-color: var(--color-admonition-tip);
+            border-bottom-color: var(--color-admonition-tip);
+          }
+        }
+      }
+    }
   }
 
   .admonitionblock.warning {
@@ -913,6 +993,26 @@
 
     strong {
       color: var(--color-admonition-warning-text);
+    }
+
+    table.tableblock {
+      td {
+        border-top-color: var(--color-admonition-warning);
+        border-bottom-color: var(--color-admonition-warning);
+      }
+
+      thead th {
+        border-bottom-color: var(--color-admonition-warning);
+      }
+
+      > {
+      :not(thead) {
+          th {
+            border-top-color: var(--color-admonition-warning);
+            border-bottom-color: var(--color-admonition-warning);
+          }
+        }
+      }
     }
   }
 

--- a/src/stylesheets/globals/vars.scss
+++ b/src/stylesheets/globals/vars.scss
@@ -46,8 +46,8 @@
   --color-higlight-link-light: #005889;
   --color-footer-light: #e6e6e6;
   --color-card-border-light: #ebf2f2;
-  --color-code-background-light: #f1f1f1;
-  --color-code-font-light: #d36700;
+  --color-code-background-light: #f9f2f4;
+  --color-code-font-light: #c7254e;
   // Dark color set
   --color-white-dark: #151a25;
   --color-text-light-dark: #556;


### PR DESCRIPTION
Use dedicated colors for table separators in admonitions: the default gray leads to some unwanted visual effects when used in admonitions: A tiny gray line with a green background looks a bite pink, with a purple background it looks a bit green, and so on for other admonitions. 

So instead of keeping this, I use dedicated colors for table separator in admonitions. 

Before: 

<img width="1373" alt="Capture d’écran 2022-01-31 à 10 32 30" src="https://user-images.githubusercontent.com/24225293/151775455-d89c5c8b-062d-476b-8dfd-ebde623458ab.png">
<img width="1373" alt="Capture d’écran 2022-01-31 à 10 32 46" src="https://user-images.githubusercontent.com/24225293/151775464-14898f43-179a-420b-8599-933240f0451e.png">

After: 

<img width="1401" alt="Capture d’écran 2022-01-31 à 11 05 09" src="https://user-images.githubusercontent.com/24225293/151775513-a76299a8-1acb-4b59-afa2-e7b63c628a01.png">
<img width="1461" alt="Capture d’écran 2022-01-31 à 11 06 10" src="https://user-images.githubusercontent.com/24225293/151775771-4a8276c1-4896-4ec5-82d0-b2e685f33e9b.png">


