### PR TITLE
feat(custom message): always display the message in a page, no matter the scroll

### DIFF
--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -50,6 +50,8 @@ var colors = [
   '--color-card-border',
   '--color-code-background',
   '--color-code-font',
+  '--color-info-custom-message-bg',
+  '--color-important-custom-message-bg',
 ]
 
 var filters = [

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -9,32 +9,6 @@
       If you typed the URL of this page manually, please double check that you entered the address correctly.</p>
   </div>
   {{else}}
-  {{#if page.attributes.out-of-support}}
-  <div class="paragraph out-of-support-block">
-    <p>This documentation is about a version that is <b>out of support</b>, here is the <a
-        href="{{{page.component.latestVersion.url}}}">latest documentation
-        version</a>.
-    </p>
-    <p>
-      How about <a href="https://www.bonitasoft.com/downloads">downloading</a> a newer, supported
-      version?
-    </p>
-  </div>
-  {{/if}}
-  {{#if page.attributes.next-release}}
-  <div class="paragraph next-release-block">
-    <p>This content is dedicated to our next version.
-      It is work in progress: its content will evolve until the new version is released.
-      Before that time, it cannot be considered as official.
-    </p>
-  </div>
-  {{/if}}
-
-  {{#if page.attributes.custom-message}}
-  <div class="paragraph next-release-block">
-    <p>{{page.attributes.custom-message}}</p>
-  </div>
-  {{/if}}
 
   {{#with page.title}}
   <h1 class="page">{{{this}}}</h1>

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -44,13 +44,13 @@
 
     <div class="navbar-search" id="search-container">
       {{#unless site.keys.nonProduction}}
-        {{#unless page.attributes.hide-search-bar }}
-        <div class="navbar-item search-item hide-for-print">
-          {{!-- Algolia search bar --}}
-          <input type="text" placeholder="Search Docs" class="search-bar query ds-input" id="search-query">
-          <i class="search-icon" aria-hidden="true"></i>
-        </div>
-        {{/unless}}
+      {{#unless page.attributes.hide-search-bar }}
+      <div class="navbar-item search-item hide-for-print">
+        {{!-- Algolia search bar --}}
+        <input type="text" placeholder="Search Docs" class="search-bar query ds-input" id="search-query">
+        <i class="search-icon" aria-hidden="true"></i>
+      </div>
+      {{/unless}}
       {{/unless}}
 
       {{!-- Dark theme --}}

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -16,7 +16,7 @@
     {{/if}}
     {{/unless}}
   </div>
-  {{#if page.attributes.out-of-support}}
+  {{!-- {{#if page.attributes.out-of-support}} --}}
   <div class="paragraph notice out-of-support-block">
     <p>This documentation is about a version that is <b>out of support</b>, here is the <a
         href="{{{page.component.latestVersion.url}}}">latest documentation
@@ -27,15 +27,15 @@
       version?
     </p>
   </div>
-  {{/if}}
-  {{!-- {{#if page.attributes.next-release}} --}}
+  {{!-- {{/if}} --}}
+  {{#if page.attributes.next-release}}
   <div class="paragraph notice custom-message-block">
     <p>This content is dedicated to our next version.
       It is work in progress: its content will evolve until the new version is released.
       Before that time, it cannot be considered as official.
     </p>
   </div>
-  {{!-- {{/if}} --}}
+  {{/if}}
   {{#if page.attributes.custom-message}}
   <div class="paragraph notice custom-message-block">
     <p>{{page.attributes.custom-message}}</p>

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -1,17 +1,44 @@
-<div class="toolbar" role="navigation">
-  {{> nav-toggle}}
-  {{#with site.homeUrl}}
-  <a href="{{{relativize this}}}" class="home-link{{#if @root.page.home}} is-current{{/if}}"></a>
-  {{/with}}
-  {{> breadcrumbs}}
-  {{> page-versions}}
-  {{#unless site.keys.hideEditPageLinks}}
-  {{#if page.attributes.editable}}
-  {{#if (and page.fileUri (not env.CI))}}
-  <div class="edit-this-page"><a href="{{page.fileUri}}">Edit this Page</a></div>
-  {{else if (and page.editUrl (or env.FORCE_SHOW_EDIT_PAGE_LINK (not page.origin.private)))}}
-  <div class="edit-this-page"><a href="{{page.editUrl}}">Edit this Page</a></div>
+<div class="toolbar toolbar-wrap">
+  <div class="toolbar" role="navigation">
+    {{> nav-toggle}}
+    {{#with site.homeUrl}}
+    <a href="{{{relativize this}}}" class="home-link{{#if @root.page.home}} is-current{{/if}}"></a>
+    {{/with}}
+    {{> breadcrumbs}}
+    {{> page-versions}}
+    {{#unless site.keys.hideEditPageLinks}}
+    {{#if page.attributes.editable}}
+    {{#if (and page.fileUri (not env.CI))}}
+    <div class="edit-this-page"><a href="{{page.fileUri}}">Edit this Page</a></div>
+    {{else if (and page.editUrl (or env.FORCE_SHOW_EDIT_PAGE_LINK (not page.origin.private)))}}
+    <div class="edit-this-page"><a href="{{page.editUrl}}">Edit this Page</a></div>
+    {{/if}}
+    {{/if}}
+    {{/unless}}
+  </div>
+  {{#if page.attributes.out-of-support}}
+  <div class="paragraph notice out-of-support-block">
+    <p>This documentation is about a version that is <b>out of support</b>, here is the <a
+        href="{{{page.component.latestVersion.url}}}">latest documentation
+        version</a>.
+    </p>
+    <p>
+      How about <a href="https://www.bonitasoft.com/downloads">downloading</a> a newer, supported
+      version?
+    </p>
+  </div>
   {{/if}}
+  {{#if page.attributes.next-release}}
+  <div class="paragraph notice custom-message-block">
+    <p>This content is dedicated to our next version.
+      It is work in progress: its content will evolve until the new version is released.
+      Before that time, it cannot be considered as official.
+    </p>
+  </div>
   {{/if}}
-  {{/unless}}
+  {{#if page.attributes.custom-message}}
+  <div class="paragraph notice custom-message-block">
+    <p>{{page.attributes.custom-message}}</p>
+  </div>
+  {{/if}}
 </div>

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -28,14 +28,14 @@
     </p>
   </div>
   {{/if}}
-  {{#if page.attributes.next-release}}
+  {{!-- {{#if page.attributes.next-release}} --}}
   <div class="paragraph notice custom-message-block">
     <p>This content is dedicated to our next version.
       It is work in progress: its content will evolve until the new version is released.
       Before that time, it cannot be considered as official.
     </p>
   </div>
-  {{/if}}
+  {{!-- {{/if}} --}}
   {{#if page.attributes.custom-message}}
   <div class="paragraph notice custom-message-block">
     <p>{{page.attributes.custom-message}}</p>

--- a/src/stylesheets/doc.scss
+++ b/src/stylesheets/doc.scss
@@ -1016,20 +1016,6 @@
     }
   }
 
-  .out-of-support-block {
-    background-color: var(--color-admonition-important-bg);
-    border-color: var(--color-admonition-important);
-    color: var(--color-admonition-important-text);
-    text-align: center;
-  }
-
-  .next-release-block {
-    background-color: var(--color-admonition-note-bg);
-    border-color: var(--color-admonition-note);
-    color: var(--color-admonition-note-text);
-    text-align: center;
-  }
-
   .image {
     > img {
       height: auto;

--- a/src/stylesheets/globals/vars.scss
+++ b/src/stylesheets/globals/vars.scss
@@ -99,7 +99,7 @@
   --color-card-border-dark: #9ba9c6;
   --color-code-background-dark: #30334b;
   --color-code-font-dark: #f7962e;
-  --color-info-custom-message-dark: #102541;
+  --color-info-custom-message-bg-dark: #102541;
   --color-important-custom-message-bg-dark: #342121;
   // End of color definition
   --rem-base: 18;

--- a/src/stylesheets/globals/vars.scss
+++ b/src/stylesheets/globals/vars.scss
@@ -185,7 +185,7 @@
   --footer-font-color: var(--color-gray-70);
   --footer-link-font-color: var(--color-jet-80);
   --navbar-height: calc(63 / var(--rem-base) * 1rem);
-  --toolbar-height: calc(45 / var(--rem-base) * 1rem);
+  --toolbar-height: calc(150 / var(--rem-base) * 1rem);
   --drawer-height: var(--toolbar-height);
   --body-top: var(--navbar-height);
   --body-min-height: calc(100vh - var(--body-top));

--- a/src/stylesheets/globals/vars.scss
+++ b/src/stylesheets/globals/vars.scss
@@ -48,6 +48,8 @@
   --color-card-border-light: #ebf2f2;
   --color-code-background-light: #f9f2f4;
   --color-code-font-light: #c7254e;
+  --color-info-custom-message-bg-light: #d8eaff;
+  --color-important-custom-message-bg-light: #edd3d3;
   // Dark color set
   --color-white-dark: #151a25;
   --color-text-light-dark: #556;
@@ -97,6 +99,8 @@
   --color-card-border-dark: #9ba9c6;
   --color-code-background-dark: #30334b;
   --color-code-font-dark: #f7962e;
+  --color-info-custom-message-dark: #102541;
+  --color-important-custom-message-bg-dark: #342121;
   // End of color definition
   --rem-base: 18;
   --body-font-size: 1.0625em;

--- a/src/stylesheets/toolbar.scss
+++ b/src/stylesheets/toolbar.scss
@@ -5,7 +5,6 @@
   box-shadow: 0 1px 0 var(--toolbar-border-color);
   display: flex;
   font-size: calc(15 / var(--rem-base) * 1rem);
-  height: var(--toolbar-height);
   justify-content: flex-start;
   position: sticky;
   top: var(--navbar-height);
@@ -59,6 +58,29 @@
 .edit-this-page {
   display: none;
   padding-right: 0.5rem;
+}
+
+.toolbar.toolbar-wrap {
+    flex-wrap: wrap;
+}
+
+.notice {
+  text-align: center;
+  width: 100%;
+  padding: 10px 5px;
+  position: sticky;
+}
+
+.custom-message-block {
+  background-color: var(--color-info-custom-message-bg);
+  border-color: var(--color-admonition-note);
+  color: var(--color-admonition-note-text);
+}
+
+.out-of-support-block {
+  background-color: var(--color-important-custom-message-bg);
+  border-color: var(--color-admonition-important);
+  color: var(--color-admonition-important-text);
 }
 
 @media screen and (min-width: 1024px) {


### PR DESCRIPTION
<img width="1677" alt="Capture d’écran 2022-02-07 à 15 33 09" src="https://user-images.githubusercontent.com/24225293/152808710-2f07818e-def8-4cd0-9022-78e381f0e699.png">

<img width="1677" alt="Capture d’écran 2022-02-07 à 15 32 42" src="https://user-images.githubusercontent.com/24225293/152808699-96cf0772-6e04-40ce-ac40-a8f18e216fd2.png">

closes https://github.com/bonitasoft/bonita-documentation-site/issues/274