### PR TITLE
fix(custom_message):  Fix side effect of "custom message always visible"

### DIFF
--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -32,7 +32,7 @@
   {{/if}}
 
   {{#if page.attributes.out-of-support}}
-      <div class="paragraph out-of-support-block">
+    <div class="paragraph out-of-support-block">
       <p>This documentation is about a version that is <b>out of support</b>, here is the <a
         href="{{{page.component.latest.url}}}">latest documentation
         version</a>.

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -31,7 +31,8 @@
     </div>
   {{/if}}
 
-    <div class="paragraph out-of-support-block">
+  {{#if page.attributes.out-of-support}}
+      <div class="paragraph out-of-support-block">
       <p>This documentation is about a version that is <b>out of support</b>, here is the <a
         href="{{{page.component.latest.url}}}">latest documentation
         version</a>.
@@ -41,6 +42,7 @@
         version?
       </p>
     </div>
+  {{/if}}
 
   {{/unless}}
 </div>

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -31,7 +31,6 @@
     </div>
   {{/if}}
 
-  {{#if page.attributes.out-of-support}}
     <div class="paragraph out-of-support-block">
       <p>This documentation is about a version that is <b>out of support</b>, here is the <a
         href="{{{page.component.latest.url}}}">latest documentation
@@ -42,7 +41,6 @@
         version?
       </p>
     </div>
-  {{/if}}
 
   {{/unless}}
 </div>

--- a/src/stylesheets/globals/vars.scss
+++ b/src/stylesheets/globals/vars.scss
@@ -146,7 +146,8 @@
   --footer-font-color: var(--color-gray-70);
   --footer-link-font-color: var(--color-jet-80);
   --navbar-height: calc(63 / var(--rem-base) * 1rem);
-  --toolbar-height: calc(150 / var(--rem-base) * 1rem);
+  --toolbar-height: calc(45 / var(--rem-base) * 1rem);
+  --header-message-height: calc(85 / var(--rem-base) * 1rem);
   --drawer-height: var(--toolbar-height);
   --body-top: var(--navbar-height);
   --body-min-height: calc(100vh - var(--body-top));
@@ -155,7 +156,7 @@
   --nav-panel-height: calc(var(--nav-height) - var(--drawer-height));
   --nav-panel-height--desktop: calc(var(--nav-height--desktop) - var(--drawer-height));
   --nav-width: calc(270 / var(--rem-base) * 1rem);
-  --toc-top: calc(var(--body-top) + var(--toolbar-height));
+  --toc-top: calc(var(--body-top) + var(--toolbar-height) + var(--header-message-height));
   --toc-height: calc(100vh - var(--toc-top) - 2.5rem);
   --toc-width: calc(162 / var(--rem-base) * 1rem);
   --toc-width--widescreen: calc(216 / var(--rem-base) * 1rem);

--- a/src/stylesheets/toolbar.scss
+++ b/src/stylesheets/toolbar.scss
@@ -91,6 +91,7 @@
   border-color: var(--color-admonition-note);
   color: var(--color-admonition-note-text);
   text-align: center;
+  width:100%;
 }
 
 


### PR DESCRIPTION
--toolbar-height var is back to its original value, since it was used also by version block
- A new var defines the height of the header message: --header-message-height (still hard-coded with a 2-lines message)
- A width 100% was missing for the next-release-block
