### PR TITLE
fix: don't underline link in breadcrumbs

### DIFF
--- a/preview-src/msg-block-custom-message.adoc
+++ b/preview-src/msg-block-custom-message.adoc
@@ -1,6 +1,6 @@
 = Message block - custom message
 :page-editable: true
-:page-custom-message: This is a custom message. YYou can use it, for example, for a specific announcement, especially to advertise an upcoming product.
+:page-custom-message: This is a custom message. You can use it, for example, for a specific announcement, especially to advertise an upcoming product.
 
 == Title 1
 

--- a/preview-src/msg-block-custom-message.adoc
+++ b/preview-src/msg-block-custom-message.adoc
@@ -1,0 +1,251 @@
+= Message block - custom message
+:page-editable: true
+:page-custom-message: This is a custom message. YYou can use it, for example, for a specific announcement, especially to advertise an upcoming product.
+
+== Title 1
+
+=== Paragraph 1.1
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+=== Paragraph 1.2
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+=== Paragraph 1.3
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+=== Paragraph 1.4
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.
+
+== Title 2
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.
+
+== Title 3
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.
+
+== Title 4
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.

--- a/preview-src/msg-block-next-version.adoc
+++ b/preview-src/msg-block-next-version.adoc
@@ -1,0 +1,252 @@
+= Message block - next version
+:page-editable: true
+:page-next-release: true
+
+
+== Title 1
+
+=== Paragraph 1.1
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+=== Paragraph 1.2
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+=== Paragraph 1.3
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+=== Paragraph 1.4
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.
+
+== Title 2
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.
+
+== Title 3
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.
+
+== Title 4
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.

--- a/preview-src/msg-block-out-of-support.adoc
+++ b/preview-src/msg-block-out-of-support.adoc
@@ -1,0 +1,253 @@
+= Message block - out of support
+:!page-editable:
+:page-out-of-support: true
+:page-hide-search-bar: true
+
+
+== Title 1
+
+=== Paragraph 1.1
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+=== Paragraph 1.2
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+=== Paragraph 1.3
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+=== Paragraph 1.4
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.
+
+== Title 2
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.
+
+== Title 3
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.
+
+== Title 4
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nam et scelerisque lacus.
+Sed sed ipsum venenatis, volutpat lacus vitae, laoreet arcu.
+Mauris a ex id erat feugiat imperdiet.
+Morbi sollicitudin vulputate sapien ut malesuada.
+Ut tincidunt risus libero, quis mollis nibh luctus a.
+Nam consequat nibh odio.
+Vestibulum consectetur auctor leo, a accumsan ipsum scelerisque nec.
+Morbi quis libero dui.
+Sed scelerisque malesuada diam, a imperdiet elit porta vitae.
+Praesent a scelerisque augue.
+Fusce pellentesque felis et turpis consectetur pretium.
+
+Aenean sed libero ligula.
+Nulla convallis sit amet leo sit amet venenatis.
+In faucibus nisl felis, efficitur faucibus dolor feugiat quis.
+Sed libero neque, hendrerit quis accumsan quis, iaculis vel urna.
+Morbi auctor eros eu ipsum posuere dignissim.
+Duis ac tellus mi.
+Praesent suscipit, velit egestas porttitor sodales, mi libero placerat nisl, sed tincidunt sem justo ut urna.
+
+Nam finibus eros quam, in auctor ligula suscipit et.
+Nam cursus tempor dapibus.
+Quisque a urna et ipsum auctor faucibus cursus id neque.
+Integer rutrum ac leo varius aliquet.
+Phasellus vel mauris justo.
+Fusce ipsum nisi, viverra at sodales vitae, posuere nec sapien.
+Cras pulvinar lectus augue, non pellentesque erat pharetra nec.
+
+Sed hendrerit, risus a commodo tincidunt, tellus metus fringilla quam, quis finibus nulla nisl in orci.
+Morbi libero magna, egestas vel facilisis ac, elementum sed ex.
+Nam ligula purus, lacinia vitae ultrices ut, varius vitae elit.
+Donec nec mauris risus.
+Pellentesque porta lectus vitae egestas semper.
+Pellentesque sed nibh vel leo volutpat sagittis eu in turpis.
+Curabitur purus lectus, gravida a turpis quis, tempus faucibus elit.
+Curabitur et fermentum justo, ac auctor enim.
+Ut sed pharetra justo.
+Donec enim urna, commodo sit amet turpis id, sagittis sollicitudin ante.
+Vestibulum id augue pretium, faucibus lectus ut, finibus risus.
+Pellentesque id porttitor erat.
+
+Nulla quis lacus in turpis viverra gravida.
+Ut scelerisque, libero vel tincidunt dapibus, risus felis ullamcorper velit, a commodo mi velit dictum quam.
+Duis porta sollicitudin nulla non dapibus.
+Nulla faucibus metus condimentum congue porttitor.
+Morbi sed mattis ligula, id iaculis turpis.
+Nullam vitae mi at leo commodo lobortis.
+Aliquam viverra nisl ullamcorper magna convallis tincidunt sit amet eget augue.
+Pellentesque pellentesque ex nec nisi egestas iaculis.
+Aliquam erat volutpat.
+Sed eget imperdiet massa.
+Donec ultricies nisi sit amet elementum tincidunt.
+In blandit nulla urna, vitae tempus ligula gravida quis.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Suspendisse volutpat mattis mauris, a convallis ex laoreet eu.
+Pellentesque augue turpis, elementum quis iaculis at, egestas id dolor.

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -129,3 +129,14 @@ page:
       - content: Some Code
         url: '/bonita/7.10/index.html#some-code'
         urlType: internal
+    - content: Message blocks
+      items:
+        - content: Out of support
+          url: '/bonita/7.10/msg-block-out-of-support.html'
+          urlType: internal
+        - content: Next version
+          url: '/bonita/7.10/msg-block-next-version.html'
+          urlType: internal
+        - content: Custom message
+          url: '/bonita/7.10/msg-block-custom-message.html'
+          urlType: internal

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -17,7 +17,7 @@
   </div>
 
   {{#if page.attributes.next-release}}
-    <div class="paragraph next-release-block">
+    <div class="paragraph message-block next-release-block">
       <p>This content is dedicated to our next version.
         It is work in progress: its content will evolve until the new version is released.
       </p>
@@ -28,13 +28,13 @@
   {{/if}}
 
   {{#if page.attributes.custom-message}}
-    <div class="paragraph next-release-block">
+    <div class="paragraph message-block custom-message-block">
       <p>{{page.attributes.custom-message}}</p>
     </div>
   {{/if}}
 
   {{#if page.attributes.out-of-support}}
-    <div class="paragraph out-of-support-block">
+    <div class="paragraph message-block out-of-support-block">
       <p>This documentation is about a version that is <b>out of support</b>, here is the <a
         href="{{{page.component.latest.url}}}">latest documentation
         version</a>.

--- a/src/stylesheets/toolbar.scss
+++ b/src/stylesheets/toolbar.scss
@@ -16,7 +16,6 @@
 
   a {
     color: inherit;
-    text-decoration-line: underline;
   }
 
   .edit-this-page {
@@ -79,20 +78,23 @@
   }
 }
 
+.message-block {
+  text-align: center;
+  width:100%;
+
+  a {
+    text-decoration-line: underline;
+  }
+}
+
 .out-of-support-block {
   background-color: var(--color-admonition-important-bg);
   border-color: var(--color-admonition-important);
   color: var(--color-admonition-important-text);
-  text-align: center;
-  width:100%;
 }
 
-.next-release-block {
+.next-release-block,.custom-message-block {
   background-color: var(--color-admonition-note-bg);
   border-color: var(--color-admonition-note);
   color: var(--color-admonition-note-text);
-  text-align: center;
-  width:100%;
 }
-
-


### PR DESCRIPTION
In a previous change, we made the links in the toolbar message blocks more visible by underlining them. This introduced
a side effect on the links of the breadcrumbs that were also underlined.
This is now fixed and dedicated pages have been created to easily test the rendering of all kinds of messages.

In addition, refactor the CSS classes of the message blocks
- remove duplication
- apply underline to anchor inside the message blocks, not in the other toolbar elements
- introduce a dedicated css class for custom message block for clarity (even if the definition is the same as the one
for next version block)


### Screenshots

**Live site showing the introduced issue**
[Without the issue](https://624e56d7e9c25f10b7116a7e--documentation-bonita.netlify.app/bonita/2022.1/identity/profiles-overview) | With the issue
-------- | -------- 
![docsite_no_underline_link_in_breadcrumbs_old_production_versions](https://user-images.githubusercontent.com/27200110/163558706-ad0a0429-a390-4c7d-aceb-791687a5119d.png) | ![image](https://user-images.githubusercontent.com/27200110/163559553-f0482f03-1cfd-4928-ba10-b482d0cf40f3.png) ![docsite_underline_link_in_breadcrumbs_20220408-1907](https://user-images.githubusercontent.com/27200110/163558710-6466c677-2b61-482c-b18e-540b1b10d612.png)

**New test pages**

![image](https://user-images.githubusercontent.com/27200110/163559722-7212778a-96ff-4143-8351-f4a228629618.png)




