### PR TITLE
chore: use npm insteadof gulp in github workflows

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ master ]
     paths:
+      - 'package.json'
       - 'package-lock.json'
       - 'src/**/*'
       - 'preview-src/**/*'
@@ -12,6 +13,7 @@ on:
   pull_request:
     branches: [ master ]
     paths:
+      - 'package.json'
       - 'package-lock.json'
       - 'src/**/*'
       - 'preview-src/**/*'
@@ -27,7 +29,7 @@ jobs:
       - name: Build Setup
         uses: ./.github/actions/build-setup
       - name: Bundle documentation theme
-        run: gulp bundle
+        run: npm run bundle
       - name: Upload UI bundle
         uses: actions/upload-artifact@v2
         with:
@@ -35,7 +37,7 @@ jobs:
           path: build/ui-bundle.zip
           retention-days: 7
       - name: Build preview
-        run: gulp preview:build
+        run: npm run preview:build
       - name: Upload preview
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
     paths:
+      - 'package.json'
       - 'package-lock.json'
       - 'src/**/*'
       - 'preview-src/**/*'
@@ -37,4 +38,4 @@ jobs:
           failOnError: true
           teardown: 'true'
           build: |
-            gulp preview:build
+            npm run preview:build

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "scripts": {
     "bundle": "gulp bundle",
-    "dev": "gulp preview"
+    "dev": "gulp preview",
+    "preview:build": "gulp preview:build"
   },
   "devDependencies": {
     "@csstools/postcss-sass": "^4.0.0",


### PR DESCRIPTION
We try to hide the build internals so use the same commands as described in the README file.
Also trigger the workflow run on package.json change, otherwise, npm script changes won't be tested.