### PR TITLE
doc: move example from contributing to online example

### DIFF
--- a/preview-src/admonitions.adoc
+++ b/preview-src/admonitions.adoc
@@ -1,5 +1,10 @@
 = Admonitions
 
+More details on admonition https://docs.asciidoctor.org/asciidoc/latest/blocks/admonitions[here]
+
+
+WARNING: GitHub may not render admonitions, see this https://docs.asciidoctor.org/asciidoc/latest/blocks/admonitions/#using-emoji-for-admonition-icons[asciidoc documentation] for more details.
+
 [TIP]
 This oughta do it!
 
@@ -314,9 +319,6 @@ Watch out!
 . blabla
 ----
 ====
-
-
-
 
 [NOTE]
 ====

--- a/preview-src/admonitions.adoc
+++ b/preview-src/admonitions.adoc
@@ -5,6 +5,8 @@ More details on admonition https://docs.asciidoctor.org/asciidoc/latest/blocks/a
 
 WARNING: GitHub may not render admonitions, see this https://docs.asciidoctor.org/asciidoc/latest/blocks/admonitions/#using-emoji-for-admonition-icons[asciidoc documentation] for more details.
 
+== Examples
+
 [TIP]
 This oughta do it!
 

--- a/preview-src/asciinema.adoc
+++ b/preview-src/asciinema.adoc
@@ -4,6 +4,9 @@ https://asciinema.org/[Asciinema] provides a great way for sharing shell session
 
 Once you have created a `.cast` file, you can add it to your document with the following markup
 
+// this fake block is here to add a break line between before the video
+{empty} +
+
 ++++
 <asciinema-player src="_/img/bcd.cast" speed="2" theme="monokai" title="Update case overview console output example" cols="240" rows="32"></asciinema-player>
 ++++

--- a/preview-src/asciinema.adoc
+++ b/preview-src/asciinema.adoc
@@ -1,5 +1,9 @@
 == Asciinema
 
+https://asciinema.org/[Asciinema] provides a great way for sharing shell sessions recording, making documentation more lively !
+
+Once you have created a `.cast` file, you can add it to your document with the following markup
+
 ++++
 <asciinema-player src="_/img/bcd.cast" speed="2" theme="monokai" title="Update case overview console output example" cols="240" rows="32"></asciinema-player>
 ++++

--- a/preview-src/cards.adoc
+++ b/preview-src/cards.adoc
@@ -1,5 +1,14 @@
 = Cards
 
+You can use card style in your page. Please don't abuse it, and try to only use it on index pages.
+
+.Card display in after HTML generation
+You can update *link*, *title* and description for each card.
+
+WARNING: If description in card body is too long (more than 3 lines), we will hide the excess.
+
+To do it, you need to use this following syntax:
+
 [.card-section]
 == Explore Bonita
 

--- a/preview-src/media.adoc
+++ b/preview-src/media.adoc
@@ -1,7 +1,12 @@
 == Videos
 
-// this fake block is here to add a break line between the title and the video
-{empty} +
+=== Embed videos
+
+It is possible to embed videos as it is done in Bonita 2021.1 index page: https://docs.asciidoctor.org/asciidoc/latest/macros/audio-and-video/
+
+* A default/max size is set for the mobile view
+* there is no default for the desktop view at the moment, so you should set the dimensions when declaring the `video` macro
+as in the following example
 
 video::Hl1thnPla7E[youtube, width=640,height=380]
 

--- a/preview-src/media.adoc
+++ b/preview-src/media.adoc
@@ -8,6 +8,9 @@ It is possible to embed videos as it is done in Bonita 2021.1 index page: https:
 * there is no default for the desktop view at the moment, so you should set the dimensions when declaring the `video` macro
 as in the following example
 
+// this fake block is here to add a break line before the video
+{empty} +
+
 video::Hl1thnPla7E[youtube, width=640,height=380]
 
 

--- a/preview-src/troubleshooting.adoc
+++ b/preview-src/troubleshooting.adoc
@@ -1,5 +1,18 @@
 = How to write a clean troubleshooting section
 
+This is how to create a troubleshooting:
+
+* The title should be "Troubleshooting" and not "Troubleshoot"
+* "Symptom": describes what the user experiences
+* "Cause": describes the diagnosis from Bonita perspective
+* "Possible solutions" (if there is still uncertainty about its efficiency depending on the user's context) or "Solutions" (if we know for sure it works): a step-by-step guidance to lead the user to success.
+
+* Depending on the position of the troubleshooting section in the page, you can:
+** Add a separator above the "Troubleshooting" title of the section, if this section appears at the bottom of the page and addresses the whole content of the page
+** Adapt the level of the header; it should be the same than the content it is related to
+
+* Do not add:
+** Additional lines above and below the content of the section. The title already provides a separator between the title and the content.
 
 [.troubleshooting-title]
 == Troubleshooting


### PR DESCRIPTION
Explanations were previously in the contributing documentation: see https://github.com/bonitasoft/bonita-documentation-site/pull/346