### PR TITLE
fix: js error in theme toggle initialization

### DIFF
--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -57,11 +57,14 @@
 
 <script>
   // init toggle state
-  if (localStorage.getItem('theme') === 'dark') {
-    document.getElementById('check').checked = true
-    document.getElementById('check-mobile').checked = true
-  } else {
-    document.getElementById('check').checked = false
-    document.getElementById('check-mobile').checked = false
+  const isDarkThemeEnable = localStorage.getItem('theme') === 'dark';
+  initializeThemeToggleIfAvailable('check', isDarkThemeEnable);
+  initializeThemeToggleIfAvailable('check-mobile', isDarkThemeEnable);
+
+  function initializeThemeToggleIfAvailable(elementId, checked) {
+    const checkElement = document.getElementById(elementId);
+    if(checkElement) {
+      checkElement.checked = checked;
+    }
   }
 </script>


### PR DESCRIPTION
Previously generated error like: `Uncaught TypeError: document.getElementById(...) is null`

This is because the toggle id is not the same on mobile and desktop, and we only have a single element on each device.