### PR TITLE
theme: minor theme improvement (smooth scroll, video block)

### DIFF
--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -3,6 +3,7 @@ html {
   box-sizing: border-box;
   font-size: var(--body-font-size);
   height: 100%;
+  scroll-behavior: smooth;
 }
 
 body {

--- a/src/stylesheets/doc.scss
+++ b/src/stylesheets/doc.scss
@@ -528,7 +528,7 @@
       }
     }
   }
-
+  .videoblock,
   .imageblock {
     margin: 1rem 0 0;
     display: flex;
@@ -553,6 +553,11 @@
       margin-top: 0.5rem;
       padding-bottom: 0;
     }
+  }
+
+  .videoblock iframe {
+    max-width: 100%;
+    vertical-align: middle;
   }
 
   .listingblock {
@@ -873,7 +878,7 @@
       }
 
       > {
-      :not(thead) {
+        :not(thead) {
           th {
             border-top-color: var(--color-admonition-caution);
             border-bottom-color: var(--color-admonition-caution);
@@ -922,7 +927,7 @@
       }
 
       > {
-      :not(thead) {
+        :not(thead) {
           th {
             border-top-color: var(--color-admonition-important);
             border-bottom-color: var(--color-admonition-important);
@@ -971,7 +976,7 @@
       }
 
       > {
-      :not(thead) {
+        :not(thead) {
           th {
             border-top-color: var(--color-admonition-note);
             border-bottom-color: var(--color-admonition-note);
@@ -1030,7 +1035,7 @@
       }
 
       > {
-      :not(thead) {
+        :not(thead) {
           th {
             border-top-color: var(--color-admonition-tip);
             border-bottom-color: var(--color-admonition-tip);
@@ -1079,7 +1084,7 @@
       }
 
       > {
-      :not(thead) {
+        :not(thead) {
           th {
             border-top-color: var(--color-admonition-warning);
             border-bottom-color: var(--color-admonition-warning);


### PR DESCRIPTION
Videoblock section style is like other block section (image block for example)

before
![image](https://user-images.githubusercontent.com/25297128/168280348-bf9f373a-d56e-45d4-a37a-8073bfb33ee9.png)

after
![image](https://user-images.githubusercontent.com/25297128/168280471-8085049c-6161-40cd-af01-2aac34530d01.png)


Scroll animation is improved, see this following example 

Before
![ezgif com-gif-maker](https://user-images.githubusercontent.com/25297128/168281295-0fb0e8ee-8bf9-4d6c-9bde-da34b90294f7.gif)

After

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/25297128/168281307-344e67d5-9302-4799-b208-6984305d3f96.gif)
