### PR TITLE
chore: update the latest version property in ui-model.yml

### DIFF
--- a/preview-src/bonita/2021.1/index.adoc
+++ b/preview-src/bonita/2021.1/index.adoc
@@ -1,0 +1,5 @@
+This is the home page for version `2021.1`.
+
+It is only intended to test the navigation to this version which is defined as the `latest version` of the `bonita` component.
+
+Links from the navigation section (on the left of this page) will go to the `404` error page.

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -23,7 +23,7 @@ site:
     - url: '#'
       version: '1.0'
       displayVersion: '1.0'
-    latestVersion: *latest_version_abc
+    latest: *latest_version_abc
   - &component
     name: bonita
     title: Bonita Theme
@@ -34,7 +34,7 @@ site:
       version: '2021.1'
       displayVersion: '2021.1'
     - &component_version
-      url: '#'
+      url: *home_url
       version: 'dev'
       displayVersion: 'dev'
     - url: '#'
@@ -43,7 +43,7 @@ site:
     - url: '#'
       version: '0'
       displayVersion: 'archives'
-    latestVersion: *latest_version_bonita
+    latest: *latest_version_bonita
   - name: 123
     title: Project 123
     url: '#'
@@ -58,7 +58,7 @@ site:
     - url: '#'
       version: '2.0'
       displayVersion: '2.0'
-    latestVersion: *latest_version_123
+    latest: *latest_version_123
 page:
   url: *home_url
   home: true

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -27,10 +27,10 @@ site:
   - &component
     name: bonita
     title: Bonita Theme
-    url: /bonita/2021.1/index.html
+    url: &bonita_2021-1_url /bonita/2021.1/index.html
     versions:
     - &latest_version_bonita
-      url: /bonita/2021.1/index.html
+      url: *bonita_2021-1_url
       version: '2021.1'
       displayVersion: '2021.1'
     - &component_version
@@ -95,10 +95,10 @@ page:
   versions:
   - version: '2021.1'
     displayVersion: '2021.1'
-    url: '#'
+    url: *bonita_2021-1_url
   - version: 'dev'
     displayVersion: 'dev'
-    url: '#'
+    url: *home_url
   - version: '7.9'
     displayVersion: '7.9'
     url: '#'


### PR DESCRIPTION
In Antora 3, the model is `page.component.latest`. It was previously `page.component.latestVersion`
The hbs templates have been updated but the source preview model still refers to the old property.
So the links to the latest version in preview pages weren't resolved.

### Notes

The hbs template were fixed with #80