### PR TITLE
chore: automate the ui bundle release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,35 @@
+name: Create release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
+      - name: Bundle documentation theme
+        run: npm run bundle
+      - name: Change bundle name
+        run: mv build/ui-bundle.zip build/bonita-documentation-theme-${{ env.RELEASE_VERSION }}.zip
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          artifacts: "build/bonita-documentation-theme-${{ env.RELEASE_VERSION }}.zip"
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GH_TOKEN_DOC_TRIGGER_WF }}
+          repository: bonitasoft/bonita-documentation-site
+          event-type: new_theme_bundle
+          client-payload: '{"release": "${{ env.RELEASE_VERSION }}", "file": "bonita-documentation-theme-${{ env.RELEASE_VERSION }}.zip", "url": "https://github.com/bonitasoft/bonita-documentation-theme/releases/download/${{ env.RELEASE_VERSION }}/bonita-documentation-theme-${{ env.RELEASE_VERSION }}.zip"}'

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,18 @@
+name: Create tag
+
+on:
+  workflow_dispatch:
+    inputs:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,4 +1,4 @@
-name: Create tag
+name: Start release process
 
 on:
   workflow_dispatch:

--- a/README.adoc
+++ b/README.adoc
@@ -28,18 +28,25 @@ For more details, see the https://docs.antora.org/antora-ui-default/prerequisite
 
 == Usage
 
-This repository produces a zip archive _ui-bundle.zip_. This archive is meant to be used by Antora, it is referenced in the main Antora https://github.com/bonitasoft/bonita-documentation-site/blob/master/antora-playbook.yml[configuration file]. +
-Currently, we embed the ui-bundle.zip in the main https://github.com/bonitasoft/bonita-documentation-site/tree/master/resources[documentation site repository], it is used locally at build time.
+This repository produces a zip archive _ui-bundle.zip_.
+This archive is meant to be used by Antora, it is referenced in the main Antora https://github.com/bonitasoft/bonita-documentation-site/blob/master/antora-playbook.yml[configuration file]. +
+The process to release a new version of the theme is fully automated with github actions.
 
 [TIP]
 ====
 Simple flow to 'release' a new version of the theme (i.e. use a new version of the UI bundle in the doc site):
 
-- Build locally this repository (type `npm run bundle` at the root of the repository) -> _build/ui-bundle.zip_ is created +
-- Clone the repository https://github.com/bonitasoft/bonita-documentation-site[bonita-documentation-site], and create a new branch to update the UI bundle
-- Copy the ui-bundle.zip archive in _bonita-documentation-site/resources/_, and rename it into _antora-ui-bundle.zip_ +
-- Push your changes and open a pull request, with details on the changes and eventually some links to the change commits in this repository
+- Go in the https://github.com/bonitasoft/bonita-documentation-theme/actions[Github Actions] section +
+- Select "Start release process" workflow and run the workflow
 ====
+This process will:
+
+- Create a new tag
+- Generate the theme bundle (_ui-bundle.zip_), and rename it with the release version
+- Create a new release
+- Send a Repository Dispatch event to the https://github.com/bonitasoft/bonita-documentation-site[bonita-documentation-site] repository
+
+When this event is received, a new Pull Request is created in the https://github.com/bonitasoft/bonita-documentation-site[bonita-documentation-site] repository, with an updated theme bundle URL.
 
 == Development
 

--- a/README.adoc
+++ b/README.adoc
@@ -43,7 +43,7 @@ This process will:
 
 - Create a new tag
 - Generate the theme bundle (_ui-bundle.zip_), and rename it with the release version
-- Create a new release
+- Create a new release and attach the theme bundle as a release asset
 - Send a Repository Dispatch event to the https://github.com/bonitasoft/bonita-documentation-site[bonita-documentation-site] repository
 
 When this event is received, a new Pull Request is created in the https://github.com/bonitasoft/bonita-documentation-site[bonita-documentation-site] repository, with an updated theme bundle URL.


### PR DESCRIPTION
Add new workflows to manage the release:
- create_tag action bump the version and push the tag (format: v1.0.0)
- create_release action:
  - Generate the theme bundle 
  - Update the bundle name to include the version
  - Send a Repository Dispatch event to the doc-site repo with the release version, the bundle file name and its url

Update the documentation of the release process


Covers (theme part) [Find a way to not be forced to store the Antora UI bundle in the repository](https://github.com/bonitasoft/bonita-documentation-site/issues/47)