### PR TITLE
chore(release-notes): Configure generated release notes by section

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - github_actions
+  categories:
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug fixes 🛠
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,7 @@ changelog:
     labels:
       - dependencies
       - github_actions
+      - ignore-for-release-notes
   categories:
     - title: New Features 🎉
       labels:


### PR DESCRIPTION
PRs will be separated in different sections:
- 'bug' label -> 'Bug Fixes'
- 'enhancement' label -> 'New Features'
- any other label (but the excluded ones below) -> 'Other Changes'

PRs with the following labels will be excluded from the generated release notes:
- dependencies
- github_actions
- ignore-for-release-notes (used when there is no existing tag)
 
Note that we may add other labels to exclude later, if needed.

See the release test: https://github.com/jeromecambon/bonita-documentation-theme/releases/tag/v0.27.0

Covers [Configure the theme repository GitHub auto-generated release notes](https://github.com/bonitasoft/bonita-documentation-site/issues/375)