### PR TITLE
fix: hide search bar in page 404

### DIFF
--- a/preview-src/msg-block-out-of-support.adoc
+++ b/preview-src/msg-block-out-of-support.adoc
@@ -3,6 +3,8 @@
 :page-out-of-support: true
 :page-hide-search-bar: true
 
+NOTE: This page is configured to hide the search bar.
+
 
 == Title 1
 

--- a/src/helpers/isSearchBarDisplayed.js
+++ b/src/helpers/isSearchBarDisplayed.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = (site, page) => {
+  return !(site.keys?.nonProduction || page.attributes?.['hide-search-bar'] || page.layout === '404')
+}

--- a/src/partials/article-404.hbs
+++ b/src/partials/article-404.hbs
@@ -1,0 +1,10 @@
+<article class="doc">
+<div class="pagenotfound">
+  <img src="{{{uiRootPath}}}/img/404_bonita_page.png" alt="404 drawing" style="">
+  <p>OOPS, LOOKS LIKE THE PAGE CANNOT BE FOUND...</p>
+</div>
+<div class="paragraph">
+  <p>If you arrived on this page by clicking on a link, please notify the owner of the site that the link is broken.
+    If you typed the URL of this page manually, please double check that you entered the address correctly.</p>
+</div>
+</article>

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -1,19 +1,7 @@
 <article class="doc">
-  {{#if (eq page.layout '404')}}
-    <div class="pagenotfound">
-      <img src="{{{uiRootPath}}}/img/404_bonita_page.png" alt="404 drawing" style="">
-      <p>OOPS, LOOKS LIKE THE PAGE CANNOT BE FOUND...</p>
-    </div>
-    <div class="paragraph">
-    <p>If you arrived on this page by clicking on a link, please notify the owner of the site that the link is broken.
-      If you typed the URL of this page manually, please double check that you entered the address correctly.</p>
-    </div>
-  {{else}}
-
-  {{#with page.title}}
-  <h1 class="page">{{{this}}}</h1>
-  {{/with}}
-  {{{page.contents}}}
-  {{/if}}
-  {{> pagination}}
+{{#with page.title}}
+<h1 class="page">{{{this}}}</h1>
+{{/with}}
+{{{page.contents}}}
+{{> pagination}}
 </article>

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -5,8 +5,7 @@
 <script src="{{{uiRootPath}}}/js/site.js"></script>
 
 {{!-- DocSearch only available if the search bar is displayed --}}
-{{#unless site.keys.nonProduction}}
-{{#unless page.attributes.hide-search-bar }}
+{{#if (isSearchBarDisplayed site page)}}
 <script>
   // var ALGOLIA_INSIGHTS_SRC = "https://cdn.jsdelivr.net/npm/search-insights@1.7.1";
   //
@@ -51,8 +50,8 @@
           });
       */
 </script>
-{{/unless}}
-{{/unless}}
+{{/if}}
+
 
 <script>
   let asciinemaPlayers = document.querySelectorAll('asciinema-player');

--- a/src/partials/head-styles.hbs
+++ b/src/partials/head-styles.hbs
@@ -1,11 +1,3 @@
-{{!-- DocSearch only available if the search bar is displayed --}}
-{{#unless site.keys.nonProduction}}
-  {{#unless page.attributes.hide-search-bar }}
-<!--<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2.6.3/dist/cdn/docsearch.css" integrity="sha256-tY3FCmL2d8yoJBOVyC2aOxdixg8sLT6CHlDWX/VUJaY=" crossorigin="anonymous">-->
-
-  {{/unless}}
-{{/unless}}
-
 <link rel="stylesheet" href="{{{uiRootPath}}}/stylesheets/vendor/libs.css">
 <link rel="stylesheet" href="{{{uiRootPath}}}/stylesheets/site.css">
 <link id="highlight-style-lnk" rel="stylesheet" href="{{{uiRootPath}}}/stylesheets/vendor/highlight-light.css">

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -23,13 +23,11 @@
     </div>
 
     <div class="navbar-end" id="search-container">
-      {{#unless site.keys.nonProduction}}
-      {{#unless page.attributes.hide-search-bar }}
+      {{#if (isSearchBarDisplayed site page)}}
       <div class="navbar-item search-item hide-for-print">
         <div id="docsearch"></div>
       </div>
-      {{/unless}}
-      {{/unless}}
+      {{/if}}
 
       <div class="theme-switch-wrapper">
         <input type="checkbox" class="checkbox" onclick="toggleDarkThemeMode(this)" id="check">

--- a/src/partials/main.hbs
+++ b/src/partials/main.hbs
@@ -1,7 +1,11 @@
 <main class="article">
 {{> toolbar}}
   <div class="content">
+{{#if (eq page.layout '404')}}
+{{> article-404}}
+{{else}}
 {{> article}}
 {{> toc}}
+{{/if}}
   </div>
 </main>


### PR DESCRIPTION
Previously, the 404-page display the search bar that did a search on all versions of all components
which was not convenient.

Introduce a Handlebar helper function to manage all options that hide the search bar. This removes
duplication logic.

Also include refactoring from Antora Default UI "move article tag for 404 to separate partial"
(cherry picked from commit 0706e75dd621f4e67108d2ca887be2d0a97c67fe)

closes https://github.com/bonitasoft/bonita-documentation-site/issues/271

### Tests

All preview pages display the search bar except
- the 404 page
- the out of support page as it is configured to hide it with a dedicated attribute

Locally changing the ui-model.yml to for the preview in "non production": the search bar is hidden in all pages

