### PR TITLE
theme(callout): Make asciidoc callout more visible for source code

### DIFF
--- a/src/stylesheets/doc.scss
+++ b/src/stylesheets/doc.scss
@@ -1251,6 +1251,10 @@
     width: 1.25em;
     letter-spacing: -0.25ex;
     text-indent: -0.25ex;
+    background-color: var(--color-black);
+    color: var(--color-white);
+    font-weight: bold;
+    border-color: var(--color-black);
 
     &::after {
       content: attr(data-value);


### PR DESCRIPTION
- Applied the chosen css from the issue below
- Tested light and dark themes, on Chrome/Safari/Firefox

Covers [Source code rendering: make the callout more visible](https://github.com/bonitasoft/bonita-documentation-site/issues/244)