### PR TITLE
ci: improve pr title checks

### DIFF
--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -6,11 +6,10 @@ on:
     types: [opened, edited, synchronize]
 
 jobs:
-  check-for-cc:
+  pr-title:
     runs-on: ubuntu-20.04
     steps:
-      - name: check-for-cc
-        id: check-for-cc
-        uses: agenthunt/conventional-commit-checker-action@v1.0.0
+      - name: Lint pull request title
+        uses: jef/conventional-commits-pr-action@v1
         with:
-          pr-body-regex: '(.*\n*)+(.*)'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use jef/conventional-commits-pr-action as it better verify the conventional commits rules.