### PR TITLE
chore(clean dependency): Remove unused package.json dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   },
   "dependencies": {
     "@docsearch/js": "^3.0.0",
-    "asciinema-player": "^3.0.0",
-    "highlight.js": "~10.5.0"
+    "asciinema-player": "^3.0.0"
   }
 }


### PR DESCRIPTION
Related to [retrieve highlight.js from npm](https://github.com/bonitasoft/bonita-documentation-theme/issues/126)