### PR TITLE
fix: display the images in footer and "edit this page"

### DIFF
--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -6,19 +6,19 @@
       </p>
       <p class="logos">
         <a class="logo" href="https://antora.org" title="Site generation by Antora" target="_blank" rel="noopener"><img
-          src="_/img/antora-logo.png"
+          src="{{{uiRootPath}}}/img/antora-logo.png"
           alt="Antora logo" height="30"></a>
         <a class="logo" href="https://asciidoctor.org" title="Text processing by Asciidoctor" target="_blank" rel="noopener"><img
-          src="_/img/asciidoctor-logo.svg"
+          src="{{{uiRootPath}}}/img/asciidoctor-logo.svg"
           alt="Asciidoctor logo" height="30"></a>
         <a class="logo" href="https://www.algolia.com/" title="Search by Algolia DocSearch" target="_blank" rel="noopener"><img
-          src="_/img/algolia-logo.svg"
+          src="{{{uiRootPath}}}/img/algolia-logo.svg"
           alt="Algolia logo" width="30"></a>
         <a class="logo" href="https://netlify.com" title="Site hosting by Netlify" target="_blank" rel="noopener"><img
-          src="_/img/netlify.svg"
+          src="{{{uiRootPath}}}/img/netlify.svg"
           alt="Netlify logo" height="30"></a>
         <a class="logo" href="https://surge.sh" title="Web publishing preview by Surge" target="_blank" rel="noopener"><img
-          src="_/img/surge-logo.svg"
+          src="{{{uiRootPath}}}/img/surge-logo.svg"
           alt="Surge logo" height="30"></a>
       </p>
     </div>

--- a/src/partials/page-additional-icons.hbs
+++ b/src/partials/page-additional-icons.hbs
@@ -1,6 +1,6 @@
 <a class="page-icon" href="{{{editUrlToCommitsUrl page.editUrl}}}">
-  <img src="_/img/history.svg" title="History of this page" alt="History" height="17">
+  <img src="{{{uiRootPath}}}/img/history.svg" title="History of this page" alt="History" height="17">
 </a>
 <a class="page-icon" href="https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc">
-  <img src="_/img/info.svg" title="How to contribute" alt="Contribution" height="17">
+  <img src="{{{uiRootPath}}}/img/info.svg" title="How to contribute" alt="Contribution" height="17">
 </a>

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -10,12 +10,12 @@
   {{#if page.attributes.editable}}
   {{#if (and page.fileUri (not env.CI))}}
     <div class="page-icons">
-      <a href="{{page.fileUri}}"><img src="_/img/edit.svg" title="Edit this page" alt="Edit" height="17"></a>
+      <a href="{{page.fileUri}}"><img src="{{{uiRootPath}}}/img/edit.svg" title="Edit this page" alt="Edit" height="17"></a>
       {{> page-additional-icons}}
     </div>
   {{else if (and page.editUrl (or env.FORCE_SHOW_EDIT_PAGE_LINK (not page.origin.private)))}}
     <div class="page-icons">
-      <a href="{{page.editUrl}}"><img src="_/img/edit.svg" title="Edit this page" alt="Edit" height="17"></a>
+      <a href="{{page.editUrl}}"><img src="{{{uiRootPath}}}/img/edit.svg" title="Edit this page" alt="Edit" height="17"></a>
       {{> page-additional-icons}}
     </div>
   {{/if}}


### PR DESCRIPTION
Use the `{{{uiRootPath}}}` template variable instead of hard coded path. The hard coded path works with the theme preview but not when used to build the site.

Closes #149

### For reviewers

This change requires **manual testing**.
Build a part of the site using the new bundle. See https://github.com/bonitasoft/bonita-documentation-site#using-local-ui-bundle
For instance, with something like `./build-preview-dev.bash --local-ui-bundle  --use-test-sources`