### PR TITLE
feat(page_icons): Always display the page icons

### DIFF
--- a/src/stylesheets/toolbar.scss
+++ b/src/stylesheets/toolbar.scss
@@ -75,11 +75,13 @@
   .nav-toggle {
     display: none;
   }
-
-  .page-icons {
-    display: block;
-  }
 }
+
+.page-icons {
+  display: block;
+  margin-left: auto;
+}
+
 
 .message-block {
   text-align: center;


### PR DESCRIPTION
Display the page icons (edit, history, contribute) whatever the browser window size is.
Previously the page icons were not displayed for window < 1024px.

closes #152
<!--
Covers [A page should have the Edit icon when half of a screen](https://github.com/bonitasoft/bonita-documentation-theme/issues/152)
-->