### PR TITLE
ci: use bonitasoft/actions pr-title-conventional-commits

### DIFF
--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -1,15 +1,15 @@
-name: Commit Message format check 
+name: Commit Message format check
 
 on:
-  pull_request:
-    branches: [master]
-    types: [opened, edited, synchronize]
+  pull_request_target:
+    # trigger when the PR title changes
+    types: [opened, edited, reopened]
 
 jobs:
   pr-title:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
     steps:
-      - name: Lint pull request title
-        uses: jef/conventional-commits-pr-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2


### PR DESCRIPTION
This action better conforms to Conventional Commits and provides guidelines to help to fix wrong PR titles.

### Status

It has been successfully tested in https://github.com/bonitasoft/bonita-documentation-site/pull/478