### PR TITLE
chore(deps-gha): bump actions/node from v2 to v3

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
         cache: 'npm'


### PR DESCRIPTION
Remove deprecation warnings:
  - run with node16
  - use the new way to set states and outputs