### PR TITLE
ci: always build the preview even when not publish it

### DIFF
--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -27,11 +27,14 @@ jobs:
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
       - name: Checkout
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v3
         if: github.event.action != 'closed'
       - name: Build Setup
         uses: ./.github/actions/build-setup
         if: github.event.action != 'closed'
+      - name: Build preview
+        if: github.event.action != 'closed'
+        run: npm run preview:build
       - name: Publish preview
         uses: afc163/surge-preview@v1
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
@@ -43,5 +46,4 @@ jobs:
           dist: public
           failOnError: true
           teardown: 'true'
-          build: |
-            npm run preview:build
+          build: echo "site already built"


### PR DESCRIPTION
The PR preview is not published when commits are done by dependabot or the PR is created from a fork repository. Previously, the build was also skipped in this case and some build errors weren't detected. Now, the workflow always build the preview to detect such errors.

### Other information

Detected in #120 