### PR TITLE
fix: TOC toggle position

### DIFF
--- a/src/stylesheets/nav.scss
+++ b/src/stylesheets/nav.scss
@@ -235,8 +235,8 @@ html.is-clipped--nav {
   position: absolute;
   height: calc(var(--nav-line-height) * 1em);
   width: calc(var(--nav-line-height) * 1em);
-  margin-top: 0.2em;
-  margin-left: calc(var(--nav-line-height) * -1em);
+  margin-top: 0.3em;
+  margin-left: calc(var(--nav-line-height) * -1.2em);
 }
 
 .nav-item[data-depth="0"] {


### PR DESCRIPTION
The toggle button of the navigation (TOC) is now centered on the item, and a bit moved away from the item. See [screenshots](https://github.com/bonitasoft/bonita-documentation-theme/pull/176#issuecomment-1415501794).