### PR TITLE
feat: Live reload option for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "bundle": "gulp bundle",
     "dev": "gulp preview",
+    "devlive": "export LIVERELOAD=true; gulp preview",
     "preview:build": "gulp preview:build"
   },
   "devDependencies": {


### PR DESCRIPTION
Added an npm target to enable live reload: npm run devlive.
Tested on Chrome, Safari, Firefox.
Works well with updates of CSS, preview adoc files.
Does not work well with hbs files: seems the live reload works half the time. 
That's why the live reload has not been enabled by default, but we could do it.

Closes https://github.com/bonitasoft/bonita-documentation-theme/issues/155