### PR TITLE
feat: improve the title display for PR preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 public/
 .idea/
+*.iml
 node_modules/
 *.DS_Store
 .project

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -55,8 +55,9 @@ body {
   background: var(--color-red-bonita);
 
   .navbar-item-nonProduction {
-    align-items: baseline;
-    font-size: 1.2rem;
+    align-items: center;
+    font-size: 1.3rem;
+    font-weight: bold;
     display: flex;
     line-height: var(--doc-line-height);
     padding: 0 0.5rem;


### PR DESCRIPTION
Center and enlarge the title when using the "nonProduction" mode which is activated for PR preview and archive.

### Screenshots

before | after
---- | ----
![01_before](https://user-images.githubusercontent.com/27200110/216631792-4d0dccff-8225-4992-8770-8c5a25ebe2fa.png) | ![02_after](https://user-images.githubusercontent.com/27200110/216631796-e3906907-8e47-44a2-a46a-78ad262d5aa4.png)



### Testing

This can be tested locally by
- in preview-src/ui-model.yml, set  `nonProduction: true`
- run 'npm run dev' and access to the preview