### PR TITLE
fix: Remove extra margin-top in the TOC

### DIFF
--- a/src/js/07-message-block.js
+++ b/src/js/07-message-block.js
@@ -1,10 +1,10 @@
 ;(function () {
   // Ajust 'top' css property of sidebar TOC, when message block is present
-  var sidebar = document.querySelector('aside.toc.sidebar')
+  const sidebar = document.querySelector('aside.toc.sidebar')
   if (!sidebar) return
-  var tocMenu = sidebar.querySelector('div.toc-menu')
+  const tocMenu = sidebar.querySelector('div.toc-menu')
   if (!tocMenu) return
-  var messageBlock = document.querySelector('div.message-block')
+  const messageBlock = document.querySelector('div.message-block')
   if (messageBlock) {
     tocMenu.classList.add('top-block_message')
   }

--- a/src/js/07-message-block.js
+++ b/src/js/07-message-block.js
@@ -1,0 +1,11 @@
+;(function () {
+  // Ajust 'top' css property of sidebar TOC, when message block is present
+  var sidebar = document.querySelector('aside.toc.sidebar')
+  if (!sidebar) return
+  var tocMenu = sidebar.querySelector('div.toc-menu')
+  if (!tocMenu) return
+  var messageBlock = document.querySelector('div.message-block')
+  if (messageBlock) {
+    tocMenu.classList.add('top-block_message')
+  }
+})()

--- a/src/stylesheets/globals/vars.scss
+++ b/src/stylesheets/globals/vars.scss
@@ -161,7 +161,6 @@
   --nav-panel-height: calc(var(--nav-height) - var(--drawer-height));
   --nav-panel-height--desktop: calc(var(--nav-height--desktop) - var(--drawer-height));
   --nav-width: calc(270 / var(--rem-base) * 1rem);
-  --toc-top: calc(var(--body-top) + var(--toolbar-height) + var(--header-message-height));
   --toc-height: calc(100vh - var(--toc-top) - 2.5rem);
   --toc-width: calc(162 / var(--rem-base) * 1rem);
   --toc-width--widescreen: calc(216 / var(--rem-base) * 1rem);

--- a/src/stylesheets/globals/vars.scss
+++ b/src/stylesheets/globals/vars.scss
@@ -160,6 +160,8 @@
   --nav-height--desktop: var(--body-min-height);
   --nav-panel-height: calc(var(--nav-height) - var(--drawer-height));
   --nav-panel-height--desktop: calc(var(--nav-height--desktop) - var(--drawer-height));
+  --toc-top: calc(var(--body-top) + var(--toolbar-height));
+  --toc-top-header-message: calc(var(--toc-top) + var(--header-message-height));
   --nav-width: calc(270 / var(--rem-base) * 1rem);
   --toc-height: calc(100vh - var(--toc-top) - 2.5rem);
   --toc-width: calc(162 / var(--rem-base) * 1rem);

--- a/src/stylesheets/toc.scss
+++ b/src/stylesheets/toc.scss
@@ -6,6 +6,7 @@
   .toc-menu {
     margin-right: 0.75rem;
     position: sticky;
+    top: var(--toc-top);
 
     h3 {
       display: flex;
@@ -19,6 +20,9 @@
       overflow-y: auto;
       scrollbar-width: none;
     }
+  }
+  .top-block_message {
+    top: var(--toc-top-header-message);
   }
 }
 

--- a/src/stylesheets/toc.scss
+++ b/src/stylesheets/toc.scss
@@ -6,7 +6,6 @@
   .toc-menu {
     margin-right: 0.75rem;
     position: sticky;
-    top: var(--toc-top);
 
     h3 {
       display: flex;


### PR DESCRIPTION
The 'top' css property was not needed.

Closes https://github.com/bonitasoft/bonita-documentation-theme/issues/123