### PR TITLE
feat: pass version aliases to DocSearch

### DIFF
--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -14,14 +14,11 @@
     indexName: 'bonitasoft',
     hitsPerPage: 20,
     searchParameters: {
-    {{#if page.attributes.is-latest-release}}
-      facetFilters: [["version:{{page.version}}", "version:latest"], "tags:{{page.component.name}}"],
-    {{else if page.attributes.is-next-release}}
-      facetFilters: [["version:{{page.version}}", "version:next"], "tags:{{page.component.name}}"],
+    {{#if page.attributes.version-alias}}
+      facetFilters: [["version:{{page.version}}", "version:{{page.attributes.version-alias}}"], "tags:{{page.component.name}}"],
     {{else}}
       facetFilters: [["version:{{page.version}}"], "tags:{{page.component.name}}"],
     {{/if}}
-
     }
   });
 </script>

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -6,17 +6,6 @@
 
 {{!-- DocSearch only available if the search bar is displayed --}}
 {{#if (isSearchBarDisplayed site page)}}
-<script>
-  // var ALGOLIA_INSIGHTS_SRC = "https://cdn.jsdelivr.net/npm/search-insights@1.7.1";
-  //
-  // !function (e, a, t, n, s, i, c) {
-  //   e.AlgoliaAnalyticsObject = s, e[s] = e[s] || function () {
-  //     (e[s].queue = e[s].queue || []).push(arguments)
-  //   }, i = a.createElement(t), c = a.getElementsByTagName(t)[0],
-  //     i.async = 1, i.src = n, c.parentNode.insertBefore(i, c)
-  // }(window, document, "script", ALGOLIA_INSIGHTS_SRC, "aa");
-</script>
-
 <script type="text/javascript">
   docsearch({
     container: '#docsearch',
@@ -25,30 +14,16 @@
     indexName: 'bonitasoft',
     hitsPerPage: 20,
     searchParameters: {
-      facetFilters: ["version:{{page.version}}", "tags:{{page.component.name}}"],
+    {{#if page.attributes.is-latest-release}}
+      facetFilters: [["version:{{page.version}}", "version:latest"], "tags:{{page.component.name}}"],
+    {{else if page.attributes.is-next-release}}
+      facetFilters: [["version:{{page.version}}", "version:next"], "tags:{{page.component.name}}"],
+    {{else}}
+      facetFilters: [["version:{{page.version}}"], "tags:{{page.component.name}}"],
+    {{/if}}
+
     }
   });
-  /*
-          docsearch({
-          algoliaOptions: {
-              clickAnalytics: true,
-          },
-          handleSelected: function (input, event, suggestion, datasetNumber, context) {
-              sendClickEvent(lastQueryID, lastQueryHits, suggestion);
-              input.setVal('');
-              window.location.assign(suggestion.url);
-          },
-          queryDataCallback: function (data) {
-              lastQueryID = data.results[0].queryID;
-              lastQueryHits = data.results[0].hits;
-          }
-          });
-
-          aa('init', {
-          appId: 'BH4D9OD16A',
-          apiKey: '16267f96d135c47df8454efd5b448c9a',
-          });
-      */
 </script>
 {{/if}}
 


### PR DESCRIPTION
Pass both the actual version and the version aliases (latest or next) when available.
This ensures a smooth transition when `Antora` will manage the latest and next aliases. `DocSearch` doesn't know the aliases until the site is in production and it has been re-indexed.
During the transition, the search will work for readers (as indexed with the actual version) and also after the content has been re-indexed (using the alias).

In addition, remove the old commented code related to `DocSearch` click events. We will eventually enable it later.


### Notes

See related PR: https://github.com/bonitasoft/bonita-documentation-site/pull/520

See issue: https://github.com/bonitasoft/bonita-documentation-site/issues/419



### Tests

With the DocSearch client of the Crawler, when we select 2 versions for the search, here is the body of the request

```json
{
  "requests": [
    {
      "query": "api",
      "indexName": "bonitasoft",
      "params": "attributesToRetrieve=%5B%22hierarchy.lvl0%22%2C%22hierarchy.lvl1%22%2C%22hierarchy.lvl2%22%2C%22hierarchy.lvl3%22%2C%22hierarchy.lvl4%22%2C%22hierarchy.lvl5%22%2C%22hierarchy.lvl6%22%2C%22content%22%2C%22type%22%2C%22url%22%5D&attributesToSnippet=%5B%22hierarchy.lvl1%3A10%22%2C%22hierarchy.lvl2%3A10%22%2C%22hierarchy.lvl3%3A10%22%2C%22hierarchy.lvl4%3A10%22%2C%22hierarchy.lvl5%3A10%22%2C%22hierarchy.lvl6%3A10%22%2C%22content%3A10%22%5D&snippetEllipsisText=%E2%80%A6&highlightPreTag=%3Cmark%3E&highlightPostTag=%3C%2Fmark%3E&hitsPerPage=20&facetFilters=%5B%5B%22version%3A7.11%22%2C%22version%3A7.10%22%5D%2C%5B%22tags%3Abonita%22%5D%5D"
    }
  ]
}
```

Versions parameter
```json
facetFilters: [["version:7.11","version:7.10"],["tags:bonita"]]"}]}
```

-> This is consistent with what we get in the page source ✅ 
