### PR TITLE
refactor: Fix format issue

### DIFF
--- a/gulp.d/tasks/build.js
+++ b/gulp.d/tasks/build.js
@@ -70,7 +70,7 @@ module.exports = (src, dest, preview) => () => {
   }
 
   /**
-   * Copy custom fonts
+   * Copy custom fonts (usefully for font-awesome)
    */
   function libFonts () {
     return vfs.src(config.libsFonts)
@@ -95,7 +95,8 @@ module.exports = (src, dest, preview) => () => {
       }))
       .pipe(postcss(postcssPlugins))
   }
-  merge(
+
+  const createOutputBundle = merge(
     libJs(),
     libCss(),
     scss(),
@@ -145,7 +146,7 @@ module.exports = (src, dest, preview) => () => {
     //vfs.src(require.resolve('<package-name-or-require-path>'), opts).pipe(concat('js/vendor/<library-name>.js')),
     vfs.src(['js/vendor/*.min.js'], { ...opts }),
     vfs.src('stylesheets/vendor/*.css', { ...opts }),
-    vfs.src(`${dest}/font/*.{ttf,woff*(2)}`, opts),
+    vfs.src('font/*.{ttf,woff*(2)}', opts),
     vfs.src('img/**/*.{gif,ico,jpg,png,svg}', opts).pipe(
       preview
         ? through()
@@ -169,6 +170,5 @@ module.exports = (src, dest, preview) => () => {
     vfs.src('partials/*.hbs', opts)
   ).pipe(vfs.dest(dest, { sourcemaps: sourcemaps && '.' }))
 
-  // TODO: perform merge op and font processing sequentially
-  return libFonts()
+  return merge(createOutputBundle, libFonts())
 }


### PR DESCRIPTION
* In 37df10aa7b685b60c20d0aa7541ee36ab920396c we introduce new font resource in the final bundle. When we added it, we put it at the end of the build sequence, but it's break some part generation (layout>default.hbs.js is missing sometimes)

* In this commit, we do the "oldest bundle", and we add customFont in the bundle.