### PR TITLE
feat: let display the search bar in preview

### DIFF
--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -1,9 +1,10 @@
 antoraVersion: 'dev-for-bonita-documentation-theme'
 site:
   keys:
-    nonProduction: false
+    forceDisplaySearchBar: false
     hideEditPageLinks: false
     hideNavbarComponentsList: false
+    nonProduction: false
   # Can be changed by setting the BONITA_THEME_URL environment variable when building
   url: http://localhost:5252
   title: Bonita Documentation Theme Preview

--- a/src/helpers/isSearchBarDisplayed.js
+++ b/src/helpers/isSearchBarDisplayed.js
@@ -1,5 +1,5 @@
 'use strict'
 
 module.exports = (site, page) => {
-  return !page.layout === '404' && !page.attributes?.['hide-search-bar'] && (site.keys?.forceDisplaySearchBar || !site.keys?.nonProduction)
+  return page.layout !== '404' && !page.attributes?.['hide-search-bar'] && (site.keys?.forceDisplaySearchBar || !site.keys?.nonProduction)
 }

--- a/src/helpers/isSearchBarDisplayed.js
+++ b/src/helpers/isSearchBarDisplayed.js
@@ -1,5 +1,7 @@
 'use strict'
 
 module.exports = (site, page) => {
-  return page.layout !== '404' && !page.attributes?.['hide-search-bar'] && (site.keys?.forceDisplaySearchBar || !site.keys?.nonProduction)
+  return page.layout !== '404' &&
+    !page.attributes?.['hide-search-bar'] &&
+    (site.keys?.forceDisplaySearchBar || !site.keys?.nonProduction)
 }

--- a/src/helpers/isSearchBarDisplayed.js
+++ b/src/helpers/isSearchBarDisplayed.js
@@ -1,5 +1,5 @@
 'use strict'
 
 module.exports = (site, page) => {
-  return !(site.keys?.nonProduction || page.attributes?.['hide-search-bar'] || page.layout === '404')
+  return !page.layout === '404' && !page.attributes?.['hide-search-bar'] && (site.keys?.forceDisplaySearchBar || !site.keys?.nonProduction)
 }


### PR DESCRIPTION
Even when the site is built in non production mode (specific nav bar color), this change lets display the search bar in the pages where the search bar is not hidden. This will let test the search in PR preview in the documentation-site repository.

Relates to https://github.com/bonitasoft/bonita-documentation-site/pull/520

### Notes

Tests done with https://github.com/bonitasoft/bonita-documentation-site/pull/558