### PR TITLE
ci: update workflows and github token permissions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
+      contents: write # create the GH release
     steps:
       - uses: actions/checkout@v3
       - name: Set env

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -2,13 +2,10 @@ name: Start release process
 
 on:
   workflow_dispatch:
-    inputs:
 
 jobs:
   build:
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Bump version and push tag

--- a/.github/workflows/publish-online-example.yml
+++ b/.github/workflows/publish-online-example.yml
@@ -34,6 +34,8 @@ jobs:
     if: github.event.ref == 'refs/heads/master'
     runs-on: ubuntu-22.04
     needs: generate_theme_example
+    permissions:
+      contents: write # Push to gh-pages
     steps:
       - name: Download
         uses: actions/download-artifact@v3


### PR DESCRIPTION
- create-release.yml: add a comment to explain why the write permission is set
- create-tag.yml: remove permission declaration as we use a PAT to create the tag
- publish-online-example.yml: push to the `gh-pages` branch

### Notes

This PR applies to this repository the same configuration as we already did for documentation content repositories: see https://github.com/bonitasoft/bonita-documentation-site/issues/443

Documentation of the actions whose permissions changed
- https://github.com/anothrNick/github-tag-action
- https://github.com/ncipollo/release-action
- https://github.com/peaceiris/actions-gh-pages