### PR TITLE
ci: make the PR preview always available as a GH artifact

### DIFF
--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Build preview
         if: github.event.action != 'closed'
         run: npm run preview:build
+      - name: Upload artifact
+        if: github.event.action != 'closed' # Always upload to be able to test it locally
+        uses: actions/upload-artifact@v3
+        with:
+          name: bonita-theme-preview-pr-${{github.event.pull_request.number}}-${{github.sha}}
+          path: public
       - name: Publish preview
         uses: afc163/surge-preview@v1
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'


### PR DESCRIPTION
This lets us test the built theme preview locally whatever the author of the PR is. This is particularly useful for PR from dependabot or from fork (the preview is not published on a surge domain).