### PR TITLE
fix(postcss): fix regex to filter css to exec postcss

### DIFF
--- a/gulp.d/tasks/build.js
+++ b/gulp.d/tasks/build.js
@@ -35,7 +35,7 @@ module.exports = (src, dest, preview) => () => {
     postcssImport,
     autoprefixer(),
     postcssUrl({
-      filter: new RegExp('^src/stylesheets/[~][^/]*(?:font|face)[^/]*/.*/files/.+[.](?:ttf|woff2?)$'),
+      filter: (asset) => /^~[^/]*(?:font|typeface)[^/]*\/files\/.+[.](?:ttf|woff2?)$/.test(asset.url),
       url: (asset) => {
         const relpath = asset.pathname.substr(1)
         const abspath = require.resolve(relpath)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "asciinema-player": "^3.0.0"
       },
       "devDependencies": {
-        "@asciidoctor/tabs": "^1.0.0-beta.6",
+        "@asciidoctor/tabs": "1.0.0-beta.6",
         "@csstools/postcss-sass": "^4.0.0",
         "asciidoctor": "2.2.6",
         "autoprefixer": "~9.7",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "preview:build": "gulp preview:build"
   },
   "devDependencies": {
-    "@asciidoctor/tabs": "^1.0.0-beta.6",
+    "@asciidoctor/tabs": "1.0.0-beta.6",
     "@csstools/postcss-sass": "^4.0.0",
     "asciidoctor": "2.2.6",
     "autoprefixer": "~9.7",


### PR DESCRIPTION
Some fonts were incorrectly filtered.

Font URLs to filter are:
```
~typeface-roboto-mono/files/roboto-mono-latin-400.woff2
~typeface-roboto-mono/files/roboto-mono-latin-400.woff
~typeface-roboto-mono/files/roboto-mono-latin-500.woff2
~typeface-roboto-mono/files/roboto-mono-latin-500.woff
```