### PR TITLE
feat: provide link to related latest page for "out of support" pages

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ When this event is received, a new Pull Request is created in the https://github
 
 == Development
 
-A static or live preview of the theme is available, run `npm run dev`, or `npm run devlive` to unable the live reload. For more details, see the https://docs.antora.org/antora-ui-default/build-preview-ui/[build-preview-ui] documentation. +
+A static or live preview of the theme is available, run `npm run dev`, or `npm run devlive` to enable the live reload. For more details, see the https://docs.antora.org/antora-ui-default/build-preview-ui/[build-preview-ui] documentation. +
 ⚠️ Note that the live reload does not always work, so use it with caution. A restart of the browser, or running `npx browserslist@latest --update-db` when asked may help.
 
 To build the bundle to be used in the Antora playbook, run `npm run bundle`.

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -72,6 +72,8 @@ page:
   editUrl: https://example.com/project-bonita/edit/master/index.adoc
   origin:
     private: false
+  latest:
+    url: /bonita/latest/my-page.html
   previous:
     content: Cards
     url: '/bonita/dev/cards.html'

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -42,7 +42,7 @@
   {{#if page.attributes.out-of-support}}
     <div class="paragraph message-block out-of-support-block">
       <p>This documentation is about a version that is <b>out of support</b>, here is the <a
-        href="{{{page.component.latest.url}}}">latest documentation
+        href="{{{relativize page.latest.url}}}">latest documentation
         version</a>.
       </p>
       <p>


### PR DESCRIPTION
Previously, in the "out of support", the link to the "latest" resource was always targeting the home page of the latest version of the component.
Now, the link targets the latest version of the current page when it exists. The template use the "relativize" helper to make the url work with local file browsing

Also update the `model-ui.yml` used for the preview to demonstrate the change.


### Notes

Closes #203


### Additional tests

Tested with preview source
- see https://bonitasoft-bonita-documentation-theme-build_preview-pr-230.surge.sh/msg-block-out-of-support.html: link to https://bonitasoft-bonita-documentation-theme-build_preview-pr-230.surge.sh/latest/my-page.html (this is what is configured in model-ui.yml)
- previously, the link sent to https://bonitasoft.github.io/bonita/2021.1/index.html

Locally tested with doc-site and test data from https://github.com/bonitasoft/bonita-documentation-site/pull/762:
- command: `./build-preview-dev.bash --local-ui-bundle --use-test-sources`
- generated content: [site_test-data.zip](https://github.com/user-attachments/files/16549418/site_test-data.zip)


Locally tested with doc-site and part of the real bonita doc content
- command: `./build-preview-dev.bash --local-ui-bundle -local-sources --use-multi-repositories --component-with-branches bonita:7.11,2022.2`
- content is too large to be shared (more than 100 mb, and GitHub only accept 25 mb)


