### PR TITLE
feat: introduce a smooth transition when switching theme

### DIFF
--- a/preview-src/tabs.adoc
+++ b/preview-src/tabs.adoc
@@ -1,10 +1,18 @@
 = Tabs block
+:bonitaVersion: 10.2.1
 
 Source: https://github.com/asciidoctor/asciidoctor-tabs
 
 [tabs]
 ====
 Tab A:: Contents of Tab A.
++
+--
+[source,shell,subs="+macros,+attributes"]
+----
+docker run --name bonita -d -p 8080:8080 bonita:pass:a[{bonitaVersion}]
+----
+--
 
 Tab B::
 +

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -20,7 +20,9 @@ function isUsingSystemPreferences () {
   return !localStorage.getItem('theme')
 }
 
-const themeOrder = ['system', 'dark', 'light']
+// TODO restore system
+const themeOrder = ['dark', 'light']
+// const themeOrder = ['system', 'dark', 'light']
 
 document.addEventListener('DOMContentLoaded', () => {
   function updateTheme () {

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -74,12 +74,5 @@ document.addEventListener('DOMContentLoaded', () => {
     bodyClassList.add('theme-transition')
 
     updateTheme()
-
-    // TODO validate if this is needed
-    // Remove theme-transition class after transition completes to avoid side effects
-    // (for example, when hovering over the left menu)
-    // setTimeout(() => {
-    //   bodyClassList.remove('theme-transition')
-    // }, 3000) // TODO must be a little larger than the duration of the transition in CSS
   })
 })

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -70,13 +70,14 @@ document.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem('theme', newTheme)
     }
 
-    const bodyClassList = document.querySelector('body').classList;
+    const bodyClassList = document.querySelector('body').classList
     bodyClassList.add('theme-transition')
 
     updateTheme()
 
     // TODO validate if this is needed
-    // Remove theme-transition class after transition completes to avoid side effects (for example, when hovering over the left menu)
+    // Remove theme-transition class after transition completes to avoid side effects
+    // (for example, when hovering over the left menu)
     // setTimeout(() => {
     //   bodyClassList.remove('theme-transition')
     // }, 3000) // TODO must be a little larger than the duration of the transition in CSS

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -41,6 +41,10 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
+    // TODO improve this
+    const bodyElement = document.querySelector('body')
+    bodyElement.classList.add('theme-transition')
+
     updateHtmlThemeAttribute()
     enableHighLightJsTheme()
   }

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -5,7 +5,7 @@ function updateHtmlThemeAttribute () {
   rootHtmlElement.setAttribute('data-theme-system', isUsingSystemPreferences())
 }
 
-// Switch  HighlightJs to theme
+// Use the HighlightJs CSS file matching the theme
 function enableHighLightJsTheme () {
   const hljsCssLink = document.getElementById('highlight-style-lnk')
   if (hljsCssLink) {
@@ -28,10 +28,6 @@ function updateTheme () {
 
 // Need to be on top of the file (i.e. run at page initialization) to avoid the flash after the content loaded
 updateTheme()
-// // Need to be on top of the file (i.e. run at page initialization) to avoid the flash after the content loaded
-// updateHtmlThemeAttribute()
-// // Required to ensure that the right theme for the 'highlight.js' library is used when the page loads
-// enableHighLightJsTheme()
 
 // Check if user has set a theme preference in localStorage or in browser preferences
 function isDarkTheme () {
@@ -50,19 +46,6 @@ const themeOrder = ['dark', 'light']
 // const themeOrder = ['system', 'dark', 'light']
 
 document.addEventListener('DOMContentLoaded', () => {
-  // function updateTheme () {
-  //   const bodyClassList = document.querySelector('body').classList;
-  //   bodyClassList.add('theme-transition')
-  //
-  //   updateHtmlThemeAttribute()
-  //   enableHighLightJsTheme()
-  //
-  //   // Remove theme-transition class after transition completes to avoid side effects (for example, when hovering over the left menu)
-  //   setTimeout(() => {
-  //     bodyClassList.remove('theme-transition')
-  //   }, 3000) // TODO must be a little larger than the duration of the transition in CSS
-  // }
-
   const themeSwitcher = document.getElementById('theme-switcher')
   themeSwitcher.addEventListener('click', (_event) => {
     function getCurrentTheme () {
@@ -90,8 +73,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const bodyClassList = document.querySelector('body').classList;
     bodyClassList.add('theme-transition')
 
-    // updateHtmlThemeAttribute()
-    // enableHighLightJsTheme()
     updateTheme()
 
     // Remove theme-transition class after transition completes to avoid side effects (for example, when hovering over the left menu)

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -5,8 +5,26 @@ function updateHtmlThemeAttribute () {
   rootHtmlElement.setAttribute('data-theme-system', isUsingSystemPreferences())
 }
 
+// Switch  HighlightJs to theme
+function enableHighLightJsTheme () {
+  const hljsCssLink = document.getElementById('highlight-style-lnk')
+  if (hljsCssLink) {
+    const currentHref = hljsCssLink.getAttribute('href')
+    let cssHref = currentHref.replace('-dark', '-light')
+    if (isDarkTheme()) {
+      cssHref = currentHref.replace('-light', '-dark')
+    }
+    hljsCssLink.setAttribute('href', cssHref)
+  } else {
+    console.log('Failed to find highlight-style-lnk css link element in page, can not swap theme')
+  }
+}
+
+// TODO introduce a single function to update the theme (see duplication in updateTheme)
 // Need to be on top of the file (i.e. run at page initialization) to avoid the flash after the content loaded
 updateHtmlThemeAttribute()
+// Required to ensure that the right theme for the 'highlight.js' library is used when the page loads
+enableHighLightJsTheme()
 
 // Check if user has set a theme preference in localStorage or in browser preferences
 function isDarkTheme () {
@@ -26,27 +44,14 @@ const themeOrder = ['dark', 'light']
 
 document.addEventListener('DOMContentLoaded', () => {
   function updateTheme () {
-    // Switch  HighlightJs to theme
-    function enableHighLightJsTheme () {
-      const hljsCssLink = document.getElementById('highlight-style-lnk')
-      if (hljsCssLink) {
-        const currentHref = hljsCssLink.getAttribute('href')
-        let cssHref = currentHref.replace('-dark', '-light')
-        if (isDarkTheme()) {
-          cssHref = currentHref.replace('-light', '-dark')
-        }
-        hljsCssLink.setAttribute('href', cssHref)
-      } else {
-        console.log('Failed to find highlight-style-lnk css link element in page, can not swap theme')
-      }
-    }
-
     // TODO improve this
     const bodyElement = document.querySelector('body')
     bodyElement.classList.add('theme-transition')
 
     updateHtmlThemeAttribute()
     enableHighLightJsTheme()
+
+    // TODO after a few seconds, remove the theme-transition class
   }
 
   const themeSwitcher = document.getElementById('theme-switcher')
@@ -74,7 +79,4 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     updateTheme()
   })
-
-  // Required to ensure that the right theme for the 'highlight.js' library is used when the page loads
-  updateTheme()
 })

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -22,11 +22,11 @@ function enableHighLightJsTheme () {
 
 function updateTheme () {
   updateHtmlThemeAttribute()
-  // Required to ensure that the right theme for the 'highlight.js' library is used when the page loads
   enableHighLightJsTheme()
 }
 
-// Need to be on top of the file (i.e. run at page initialization) to avoid the flash after the content loaded
+// Ensure that the right theme is used when the page loads
+// Must be placed at the head of the page (i.e. executed at page initialization) to avoid flash after content loading
 updateTheme()
 
 // Check if user has set a theme preference in localStorage or in browser preferences

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -75,9 +75,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     updateTheme()
 
+    // TODO validate if this is needed
     // Remove theme-transition class after transition completes to avoid side effects (for example, when hovering over the left menu)
-    setTimeout(() => {
-      bodyClassList.remove('theme-transition')
-    }, 3000) // TODO must be a little larger than the duration of the transition in CSS
+    // setTimeout(() => {
+    //   bodyClassList.remove('theme-transition')
+    // }, 3000) // TODO must be a little larger than the duration of the transition in CSS
   })
 })

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -20,11 +20,18 @@ function enableHighLightJsTheme () {
   }
 }
 
-// TODO introduce a single function to update the theme (see duplication in updateTheme)
+function updateTheme () {
+  updateHtmlThemeAttribute()
+  // Required to ensure that the right theme for the 'highlight.js' library is used when the page loads
+  enableHighLightJsTheme()
+}
+
 // Need to be on top of the file (i.e. run at page initialization) to avoid the flash after the content loaded
-updateHtmlThemeAttribute()
-// Required to ensure that the right theme for the 'highlight.js' library is used when the page loads
-enableHighLightJsTheme()
+updateTheme()
+// // Need to be on top of the file (i.e. run at page initialization) to avoid the flash after the content loaded
+// updateHtmlThemeAttribute()
+// // Required to ensure that the right theme for the 'highlight.js' library is used when the page loads
+// enableHighLightJsTheme()
 
 // Check if user has set a theme preference in localStorage or in browser preferences
 function isDarkTheme () {
@@ -43,16 +50,18 @@ const themeOrder = ['dark', 'light']
 // const themeOrder = ['system', 'dark', 'light']
 
 document.addEventListener('DOMContentLoaded', () => {
-  function updateTheme () {
-    // TODO improve this
-    const bodyElement = document.querySelector('body')
-    bodyElement.classList.add('theme-transition')
-
-    updateHtmlThemeAttribute()
-    enableHighLightJsTheme()
-
-    // TODO after a few seconds, remove the theme-transition class
-  }
+  // function updateTheme () {
+  //   const bodyClassList = document.querySelector('body').classList;
+  //   bodyClassList.add('theme-transition')
+  //
+  //   updateHtmlThemeAttribute()
+  //   enableHighLightJsTheme()
+  //
+  //   // Remove theme-transition class after transition completes to avoid side effects (for example, when hovering over the left menu)
+  //   setTimeout(() => {
+  //     bodyClassList.remove('theme-transition')
+  //   }, 3000) // TODO must be a little larger than the duration of the transition in CSS
+  // }
 
   const themeSwitcher = document.getElementById('theme-switcher')
   themeSwitcher.addEventListener('click', (_event) => {
@@ -77,6 +86,17 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
       localStorage.setItem('theme', newTheme)
     }
+
+    const bodyClassList = document.querySelector('body').classList;
+    bodyClassList.add('theme-transition')
+
+    // updateHtmlThemeAttribute()
+    // enableHighLightJsTheme()
     updateTheme()
+
+    // Remove theme-transition class after transition completes to avoid side effects (for example, when hovering over the left menu)
+    setTimeout(() => {
+      bodyClassList.remove('theme-transition')
+    }, 3000) // TODO must be a little larger than the duration of the transition in CSS
   })
 })

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -41,9 +41,7 @@ function isUsingSystemPreferences () {
   return !localStorage.getItem('theme')
 }
 
-// TODO restore system
-const themeOrder = ['dark', 'light']
-// const themeOrder = ['system', 'dark', 'light']
+const themeOrder = ['system', 'dark', 'light']
 
 document.addEventListener('DOMContentLoaded', () => {
   const themeSwitcher = document.getElementById('theme-switcher')

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -25,6 +25,13 @@ body {
   &::after {
     box-sizing: inherit;
   }
+
+  // Smooth transitions between themes
+  --duration: 1s;
+  --timing: ease;
+  transition:
+    color var(--duration) var(--timing),
+    background-color var(--duration) var(--timing);
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -35,6 +35,9 @@ body.theme-transition {
 // TODO remove selector for navbar, the color and background color are the same in both light and dark
 //.navbar,
 .nav, // TODO seems that we apply the transition several times in inner elements
+.nav .context, // Components selector (title)
+.nav .components, // Components selector (list)
+
 //.nav-menu, // this seems not apply changes to the
 .toolbar,
 .hljs, // for highligtjs block

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -50,8 +50,8 @@ footer,
 footer a, // Privacy and "Legal notices"
 // home and top right icons in the toolbar/breadcrumb: use filter, so not considered for now
   {
-      --duration: 2s;
-      --timing: ease;
+      --duration: .7s;
+      --timing: linear;
       transition:
         color var(--duration) var(--timing),
         background-color var(--duration) var(--timing);

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -43,7 +43,7 @@ body.theme-transition {
 .hljs, // for highligtjs block
 .content .tabs .tabpanel, // AsciiDoc tabs
 .content .tabs .tab, // AsciiDoc tabs
-.DocSearch-Button,  // .DocSearch-Button-Key use filter, so not considered for now
+.DocSearch-Button,  // .DocSearch-Button-Key uses a gradient, so not considered for now
 footer,
 footer a, // Privacy and "Legal notices"
 // home and top right icons in the toolbar/breadcrumb: use filter, so not considered for now

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -35,6 +35,8 @@ body {
 //.nav-menu, // this seems not apply changes to the
 .toolbar,
 .hljs, // for highligtjs block
+  // TODO AsciiDoc tabs, no configured background color for dark mode
+.content .tabs, // AsciiDoc tabs
 // TODO test nested selectors body.theme-transition {
 //body.theme-transition .article,
 ////body.theme-transition .content,

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -28,15 +28,18 @@ body {
 }
   // Smooth transitions between themes
 body.theme-transition {
-// TODO remove selector for navbar, the color and background color are the same in both light and dark
+  //.doc,
+  //.sidebar,
 .article,
+// TODO remove selector for navbar, the color and background color are the same in both light and dark
 //.navbar,
-.nav, // TODO we may not apply the transition to the element of the nav
+.nav, // TODO seems that we apply the transition several times in inner elements
 //.nav-menu, // this seems not apply changes to the
 .toolbar,
 .hljs, // for highligtjs block
-  // TODO AsciiDoc tabs, no configured background color for dark mode
 .content .tabs, // AsciiDoc tabs
+  // TODO docsearch background
+
 // TODO test nested selectors body.theme-transition {
 //body.theme-transition .article,
 ////body.theme-transition .content,

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -27,31 +27,25 @@ body {
   }
 }
 
+// TODO simplify syntax with SCSS
 // Smooth transitions between themes
 body.theme-transition {
-  //.doc,
-  //.sidebar,
 .article, // body
 .doc .exampleblock .content, // raw block
 .doc .quoteblock, // raw block
 .doc .sidebarblock, // raw block
 .doc .verseblock, // raw block
-// TODO remove selector for navbar, the color and background color are the same in both light and dark
-//.navbar,
-.nav, // TODO seems that we apply the transition several times in inner elements
+.nav, // TODO check if this applies the transition several times in inner elements
 .nav .context, // Components selector (title)
 .nav .components, // Components selector (list)
-
-//.nav-menu, // this seems not apply changes to the
 .toolbar,
 .hljs, // for highligtjs block
 .content .tabs .tabpanel, // AsciiDoc tabs
 .content .tabs .tab, // AsciiDoc tabs
-.DocSearch-Button,  // TODO docsearch background
-  //.DocSearch-Button-Key, // TODO not working
+.DocSearch-Button,  // .DocSearch-Button-Key use filter, so not considered for now
 footer,
 footer a, // Privacy and "Legal notices"
-// TODO top right icons and search icon on the left of the DocSearch bar
+// TODO home and top right icons
 {
     --duration: 2s;
     --timing: ease;

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -32,6 +32,8 @@ body {
 body.theme-transition {
 .article, // body
 .doc .conum, // AsciiDoc Callouts
+.doc  code,
+.doc  kbd,
 .doc .exampleblock .content, // raw block
 .doc .quoteblock, // raw block
 .doc .sidebarblock, // raw block
@@ -47,14 +49,15 @@ body.theme-transition {
 footer,
 footer a, // Privacy and "Legal notices"
 // home and top right icons in the toolbar/breadcrumb: use filter, so not considered for now
-{
-    --duration: 2s;
-    --timing: ease;
-    transition:
-      color var(--duration) var(--timing),
-      background-color var(--duration) var(--timing);
+  {
+      --duration: 2s;
+      --timing: ease;
+      transition:
+        color var(--duration) var(--timing),
+        background-color var(--duration) var(--timing);
+  }
 }
-}
+
 
 @media screen and (min-width: 1024px) {
   html {

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -38,7 +38,7 @@ body.theme-transition {
 .doc .quoteblock, // raw block
 .doc .sidebarblock, // raw block
 .doc .verseblock, // raw block
-.nav, // TODO check if this applies the transition several times in inner elements
+.nav,
 .nav .context, // Components selector (title)
 .nav .components, // Components selector (list)
 .toolbar,

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -27,28 +27,27 @@ body {
   }
 }
 
-// TODO simplify syntax with SCSS
 // Smooth transitions between themes
 body.theme-transition {
-.article, // body
-.doc .conum, // AsciiDoc Callouts
-.doc  code,
-.doc  kbd,
-.doc .exampleblock .content, // raw block
-.doc .quoteblock, // raw block
-.doc .sidebarblock, // raw block
-.doc .verseblock, // raw block
-.nav,
-.nav .context, // Components selector (title)
-.nav .components, // Components selector (list)
-.toolbar,
-.hljs, // for highligtjs block
-.content .tabs .tabpanel, // AsciiDoc tabs
-.content .tabs .tab, // AsciiDoc tabs
-.DocSearch-Button,  // .DocSearch-Button-Key uses a gradient, so not considered for now
-footer,
-footer a, // Privacy and "Legal notices"
-// home and top right icons in the toolbar/breadcrumb: use filter, so not considered for now
+  .article, // body
+  .doc .conum, // AsciiDoc Callouts
+  .doc  code,
+  .doc  kbd,
+  .doc .exampleblock .content, // raw block
+  .doc .quoteblock, // raw block
+  .doc .sidebarblock, // raw block
+  .doc .verseblock, // raw block
+  .nav,
+  .nav .context, // Components selector (title)
+  .nav .components, // Components selector (list)
+  .toolbar,
+  .hljs, // for highligtjs block
+  .content .tabs .tabpanel, // AsciiDoc tabs
+  .content .tabs .tab, // AsciiDoc tabs
+  .DocSearch-Button,  // .DocSearch-Button-Key uses a gradient, so not considered for now
+  footer,
+  footer a, // Privacy and "Legal notices"
+  // home and top right icons in the toolbar/breadcrumb: use filter, so not considered for now
   {
       --duration: .7s;
       --timing: linear;

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -45,7 +45,8 @@ body.theme-transition {
 //.nav-menu, // this seems not apply changes to the
 .toolbar,
 .hljs, // for highligtjs block
-.content .tabs, // AsciiDoc tabs
+.content .tabs .tabpanel, // AsciiDoc tabs
+.content .tabs .tab, // AsciiDoc tabs
 .DocSearch-Button,  // TODO docsearch background
   //.DocSearch-Button-Key, // TODO not working
 footer,

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -45,7 +45,7 @@ body.theme-transition {
 .DocSearch-Button,  // .DocSearch-Button-Key use filter, so not considered for now
 footer,
 footer a, // Privacy and "Legal notices"
-// TODO home and top right icons
+// home and top right icons in the toolbar/breadcrumb: use filter, so not considered for now
 {
     --duration: 2s;
     --timing: ease;

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -26,8 +26,8 @@ body {
     box-sizing: inherit;
   }
 }
-
-// Smooth transitions between themes
+  // Smooth transitions between themes
+body.theme-transition {
 // TODO remove selector for navbar, the color and background color are the same in both light and dark
 .article,
 //.navbar,
@@ -49,6 +49,7 @@ body {
     transition:
       color var(--duration) var(--timing),
       background-color var(--duration) var(--timing);
+}
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -25,13 +25,19 @@ body {
   &::after {
     box-sizing: inherit;
   }
+}
 
-  // Smooth transitions between themes
-  --duration: 1s;
-  --timing: ease;
-  transition:
-    color var(--duration) var(--timing),
-    background-color var(--duration) var(--timing);
+// Smooth transitions between themes
+.article,
+.navbar,
+.nav-menu,
+.toolbar,
+{
+    --duration: 1s;
+    --timing: ease;
+    transition:
+      color var(--duration) var(--timing),
+      background-color var(--duration) var(--timing);
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -26,7 +26,8 @@ body {
     box-sizing: inherit;
   }
 }
-  // Smooth transitions between themes
+
+// Smooth transitions between themes
 body.theme-transition {
   //.doc,
   //.sidebar,
@@ -38,14 +39,9 @@ body.theme-transition {
 .toolbar,
 .hljs, // for highligtjs block
 .content .tabs, // AsciiDoc tabs
-  // TODO docsearch background
+.DocSearch-Button,  // TODO docsearch background
+  //.DocSearch-Button-Key, // TODO not working
 
-// TODO test nested selectors body.theme-transition {
-//body.theme-transition .article,
-////body.theme-transition .content,
-////body.theme-transition .navbar, // no needed
-//body.theme-transition .nav-menu,
-//body.theme-transition .toolbar,
 {
     --duration: 2s;
     --timing: ease;

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -31,7 +31,11 @@ body {
 body.theme-transition {
   //.doc,
   //.sidebar,
-.article,
+.article, // body
+.doc .exampleblock .content, // raw block
+.doc .quoteblock, // raw block
+.doc .sidebarblock, // raw block
+.doc .verseblock, // raw block
 // TODO remove selector for navbar, the color and background color are the same in both light and dark
 //.navbar,
 .nav, // TODO seems that we apply the transition several times in inner elements

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -31,6 +31,7 @@ body {
 // Smooth transitions between themes
 body.theme-transition {
 .article, // body
+.doc .conum, // AsciiDoc Callouts
 .doc .exampleblock .content, // raw block
 .doc .quoteblock, // raw block
 .doc .sidebarblock, // raw block

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -28,10 +28,12 @@ body {
 }
 
 // Smooth transitions between themes
-.article,
-.navbar,
-.nav-menu,
-.toolbar,
+// TODO test nested selectors body.theme-transition {
+body.theme-transition .article,
+//body.theme-transition .content,
+body.theme-transition .navbar,
+body.theme-transition .nav-menu,
+body.theme-transition .toolbar,
 {
     --duration: 1s;
     --timing: ease;

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -44,6 +44,8 @@ body.theme-transition {
 .content .tabs, // AsciiDoc tabs
 .DocSearch-Button,  // TODO docsearch background
   //.DocSearch-Button-Key, // TODO not working
+footer,
+footer a, // Privacy and "Legal notices"
 // TODO top right icons and search icon on the left of the DocSearch bar
 {
     --duration: 2s;

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -28,14 +28,21 @@ body {
 }
 
 // Smooth transitions between themes
+// TODO remove selector for navbar, the color and background color are the same in both light and dark
+.article,
+//.navbar,
+.nav, // TODO we may not apply the transition to the element of the nav
+//.nav-menu, // this seems not apply changes to the
+.toolbar,
+.hljs, // for highligtjs block
 // TODO test nested selectors body.theme-transition {
-body.theme-transition .article,
-//body.theme-transition .content,
-body.theme-transition .navbar,
-body.theme-transition .nav-menu,
-body.theme-transition .toolbar,
+//body.theme-transition .article,
+////body.theme-transition .content,
+////body.theme-transition .navbar, // no needed
+//body.theme-transition .nav-menu,
+//body.theme-transition .toolbar,
 {
-    --duration: 1s;
+    --duration: 2s;
     --timing: ease;
     transition:
       color var(--duration) var(--timing),

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -41,7 +41,7 @@ body.theme-transition {
 .content .tabs, // AsciiDoc tabs
 .DocSearch-Button,  // TODO docsearch background
   //.DocSearch-Button-Key, // TODO not working
-
+// TODO top right icons and search icon on the left of the DocSearch bar
 {
     --duration: 2s;
     --timing: ease;

--- a/src/stylesheets/doc.scss
+++ b/src/stylesheets/doc.scss
@@ -1,6 +1,11 @@
+.article {
+  background-color: var(--body-background); // needed for smooth theme transition
+}
+
 /* NEEDS REVIEW prevent pre in table from causing article to exceed bounds */
 /* NOTE assume pre.highlight contains code[data-lang] */
 .doc {
+  //background-color: var(--body-background); // needed for smooth theme transition
   color: var(--doc-font-color);
   font-size: var(--doc-font-size);
   hyphens: auto;

--- a/src/stylesheets/doc.scss
+++ b/src/stylesheets/doc.scss
@@ -5,7 +5,6 @@
 /* NEEDS REVIEW prevent pre in table from causing article to exceed bounds */
 /* NOTE assume pre.highlight contains code[data-lang] */
 .doc {
-  //background-color: var(--body-background); // needed for smooth theme transition
   color: var(--doc-font-color);
   font-size: var(--doc-font-size);
   hyphens: auto;

--- a/src/stylesheets/nav.scss
+++ b/src/stylesheets/nav.scss
@@ -103,6 +103,7 @@ html.is-clipped--nav {
   max-height: calc(50% + var(--drawer-height));
 
   .context {
+    background-color: var(--body-background); // needed for smooth theme transition
     font-size: calc(15 / var(--rem-base) * 1rem);
     flex-shrink: 0;
     color: var(--nav-muted-color);


### PR DESCRIPTION
Apply a transition to the color and background color of elements on all pages.

Limitations: the transition doesn't apply to the following elements:
- DocSearch button keys (gradient)
- home and top right icons in the toolbar/breadcrumb (filter)

### Notes

Closes #122

### Videos

> [!NOTE]
> In the following video, transitions are only made from dark to light and vice versa (no use of system preferences). This is for ease of illustration.
The use of system preferences is still available in the final implementation.

[PR_232_20250226-1358_theme_smooth_transition.webm](https://github.com/user-attachments/assets/1281f073-d455-4d12-8a65-8238a5638f11)



### Tasks

- [x] review transition duration
- [x] add screenshot/video with admonition, block, code example, expanded version selector, ....
- [x] restore the "system preferences" state: it had been disabled to ease development
- [x] with 95e7119, the transition applies to all background changes: for example, when moving the hover on elements of the nav (taxonomy) on the left of the page. We may reduce the duration of the transition because of that or find an alternative
- [x] on Chrome with 95e7119, the transition seems to be applied several times: when the page loads, the transition takes a very long time.