### PR TITLE
feat(out-of-support): make the message clearer

### DIFF
--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -42,7 +42,7 @@
   {{#if page.attributes.out-of-support}}
     <div class="paragraph message-block out-of-support-block">
       <p>This documentation is for a version that is <b>out of support</b>.</p>
-      <p>Here is the <a href="{{{relativize page.latest.url}}}">latest documentation version</a>.</p>
+      <p>You may want to view the same page for the <a href="{{{relativize page.latest.url}}}">latest version</a>.</p>
     </div>
   {{/if}}
 

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -41,7 +41,7 @@
 
   {{#if page.attributes.out-of-support}}
     <div class="paragraph message-block out-of-support-block">
-      <p>This documentation is for a version that is <b>out of support</b></p>
+      <p>This documentation is for a version that is <b>out of support</b>.</p>
       <p>Here is the <a href="{{{relativize page.latest.url}}}">latest documentation version</a>.</p>
     </div>
   {{/if}}

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -41,14 +41,8 @@
 
   {{#if page.attributes.out-of-support}}
     <div class="paragraph message-block out-of-support-block">
-      <p>This documentation is about a version that is <b>out of support</b>, here is the <a
-        href="{{{relativize page.latest.url}}}">latest documentation
-        version</a>.
-      </p>
-      <p>
-        How about <a href="https://www.bonitasoft.com/downloads">downloading</a> a newer, supported
-        version?
-      </p>
+      <p>This documentation is for a version that is <b>out of support</b></p>
+      <p>You may want to view the same page for the <a href="{{{relativize page.latest.url}}}">latest version</a>.</p>
     </div>
   {{/if}}
 

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -42,7 +42,7 @@
   {{#if page.attributes.out-of-support}}
     <div class="paragraph message-block out-of-support-block">
       <p>This documentation is for a version that is <b>out of support</b></p>
-      <p>You may want to view the same page for the <a href="{{{relativize page.latest.url}}}">latest version</a>.</p>
+      <p>Here is the <a href="{{{relativize page.latest.url}}}">latest documentation version</a>.</p>
     </div>
   {{/if}}
 

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -42,7 +42,7 @@
   {{#if page.attributes.out-of-support}}
     <div class="paragraph message-block out-of-support-block">
       <p>This documentation is for a version that is <b>out of support</b>.</p>
-      <p>You may want to view the same page for the <a href="{{{relativize page.latest.url}}}">latest version</a>.</p>
+      <p>You may want to view the same page for the <a href="{{{relativize page.latest.url}}}">latest version</a>, or for any of the versions available in the drop-down menu in the top-right corner.</p>
     </div>
   {{/if}}
 


### PR DESCRIPTION
Also remove the link to the downloads page are it doesn't relate to the documentation but to the
products themselves.

Here, we want to warn the reader about an outdated documentation content, not about its usage of
an out-of support product.





### Proposals


previous implementation | 179a073 | e09219b
---- | ---- | ----
![previous](https://github.com/user-attachments/assets/63c8107e-f057-40a6-9ed4-a1561535608f) |  ![proposition_01](https://github.com/user-attachments/assets/e1d7f6f4-ac77-4e5a-b15e-eb44b9226cb1) | ![proposition_02](https://github.com/user-attachments/assets/91f76628-c374-408e-b333-7ef757ecc85d)


### Inspirations

Inspired by the Posgres documentation: https://www.postgresql.org/docs/11/app-createdb.html

![image](https://github.com/user-attachments/assets/d03d4c77-455d-4bcf-8bdb-fd4732d78037)


### Reviews

I'm waiting for the feedback I've requested from people who use out of support content or who are in contact with customers using such content:
- @ugaston

ℹ️ Test page: https://bonitasoft-bonita-documentation-theme-build_preview-pr-234.surge.sh/msg-block-out-of-support.html
