### PR TITLE
feat: choose theme based on system preferences

### DIFF
--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
-function updateHtmlThemeAttribute() {
-  const rootHtmlElement = document.querySelector('html');
+function updateHtmlThemeAttribute () {
+  const rootHtmlElement = document.querySelector('html')
   rootHtmlElement.setAttribute('data-theme', isDarkTheme() ? 'dark' : 'light')
   rootHtmlElement.setAttribute('data-theme-system', isUsingSystemPreferences())
 }
@@ -16,7 +16,7 @@ function isDarkTheme () {
     : localThemeSetting === 'dark'
 }
 
-function isUsingSystemPreferences() {
+function isUsingSystemPreferences () {
   return !localStorage.getItem('theme')
 }
 
@@ -46,14 +46,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const themeSwitcher = document.getElementById('theme-switcher')
   themeSwitcher.addEventListener('click', (_event) => {
-    const currentTheme = isUsingSystemPreferences() ? 'system' : isDarkTheme() ? 'dark' : 'light'
+    function getCurrentTheme () {
+      if (isUsingSystemPreferences()) {
+        return 'system'
+      } else {
+        return isDarkTheme() ? 'dark' : 'light'
+      }
+    }
+
+    const currentTheme = getCurrentTheme()
 
     const newTheme = themeOrder.indexOf(currentTheme) === themeOrder.length - 1
-      ?  themeOrder[0]
-      :  themeOrder[themeOrder.indexOf(currentTheme) + 1]
+      ? themeOrder[0]
+      : themeOrder[themeOrder.indexOf(currentTheme) + 1]
 
-    // 3 states are managed with a single variable. When theme is undefined, it means that the theme is managed by system preferences
-    if(newTheme === 'system') {
+    // 3 states are managed with a single variable
+    // When theme is undefined, it means that the theme is managed by system preferences
+    if (newTheme === 'system') {
       localStorage.removeItem('theme')
     } else {
       localStorage.setItem('theme', newTheme)

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -21,7 +21,6 @@ function isUsingSystemPreferences () {
 }
 
 const themeOrder = ['system', 'dark', 'light']
-// let currentTheme = null;
 
 document.addEventListener('DOMContentLoaded', () => {
   function updateTheme () {

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -1,6 +1,12 @@
 /* eslint-disable no-undef */
-// Need to be on top of the file to avoid the flash after the content loaded
-document.querySelector('html').setAttribute('data-theme', isDarkTheme() ? 'dark' : 'light')
+function updateHtmlThemeAttribute() {
+  const rootHtmlElement = document.querySelector('html');
+  rootHtmlElement.setAttribute('data-theme', isDarkTheme() ? 'dark' : 'light')
+  rootHtmlElement.setAttribute('data-theme-system', isUsingSystemPreferences())
+}
+
+// Need to be on top of the file (i.e. run at page initialization) to avoid the flash after the content loaded
+updateHtmlThemeAttribute()
 
 // Check if user has set a theme preference in localStorage or in browser preferences
 function isDarkTheme () {
@@ -10,15 +16,22 @@ function isDarkTheme () {
     : localThemeSetting === 'dark'
 }
 
+function isUsingSystemPreferences() {
+  return !localStorage.getItem('theme')
+}
+
+const themeOrder = ['system', 'dark', 'light']
+// let currentTheme = null;
+
 document.addEventListener('DOMContentLoaded', () => {
-  function updateTheme (isDarkTheme) {
+  function updateTheme () {
     // Switch  HighlightJs to theme
-    function enableHighLightJsTheme (isDarkTheme) {
+    function enableHighLightJsTheme () {
       const hljsCssLink = document.getElementById('highlight-style-lnk')
       if (hljsCssLink) {
         const currentHref = hljsCssLink.getAttribute('href')
         let cssHref = currentHref.replace('-dark', '-light')
-        if (isDarkTheme) {
+        if (isDarkTheme()) {
           cssHref = currentHref.replace('-light', '-dark')
         }
         hljsCssLink.setAttribute('href', cssHref)
@@ -26,19 +39,39 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log('Failed to find highlight-style-lnk css link element in page, can not swap theme')
       }
     }
-    document.querySelector('html').setAttribute('data-theme', isDarkTheme ? 'dark' : 'light')
-    enableHighLightJsTheme(isDarkTheme)
+
+    updateHtmlThemeAttribute()
+    enableHighLightJsTheme()
   }
 
-  const checkboxTheme = document.getElementById('theme-switch')
+  const themeSwitcher = document.getElementById('theme-switcher')
+  themeSwitcher.addEventListener('click', (_event) => {
+    console.log('@@click on theme selector')
+    console.log('localStorage:', localStorage)
+    const currentTheme = isUsingSystemPreferences() ? 'system' : isDarkTheme() ? 'dark' : 'light'
+    console.log('computed current theme:', currentTheme)
 
-  checkboxTheme.addEventListener('change', (event) => {
-    const isDarkTheme = event.currentTarget.checked
-    localStorage.setItem('theme', isDarkTheme ? 'dark' : 'light')
-    updateTheme(isDarkTheme)
+    const newTheme = themeOrder.indexOf(currentTheme) === themeOrder.length - 1
+      ?  themeOrder[0]
+      :  themeOrder[themeOrder.indexOf(currentTheme) + 1]
+    console.log('New theme:', newTheme)
+
+    // 3 states are managed with a single variable. When theme is undefined, it means that the theme is managed by system preferences
+    if(newTheme === 'system') {
+      console.log('@@device theme')
+      localStorage.removeItem('theme')
+      console.log('@@device theme - localStorage:', localStorage)
+    } else {
+      console.log('@@non device theme')
+      localStorage.setItem('theme', newTheme)
+    }
+    console.log('localStorage:', localStorage)
+
+    updateTheme()
   })
 
-  const darkThemeChecked = isDarkTheme()
-  updateTheme(darkThemeChecked)
-  checkboxTheme.checked = darkThemeChecked
+  console.log('@@INIT localStorage:', localStorage)
+
+  // Required to ensure that the right theme for the 'highlight.js' library is used when the page loads
+  updateTheme()
 })

--- a/src/js/header-01-theme.js
+++ b/src/js/header-01-theme.js
@@ -46,31 +46,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const themeSwitcher = document.getElementById('theme-switcher')
   themeSwitcher.addEventListener('click', (_event) => {
-    console.log('@@click on theme selector')
-    console.log('localStorage:', localStorage)
     const currentTheme = isUsingSystemPreferences() ? 'system' : isDarkTheme() ? 'dark' : 'light'
-    console.log('computed current theme:', currentTheme)
 
     const newTheme = themeOrder.indexOf(currentTheme) === themeOrder.length - 1
       ?  themeOrder[0]
       :  themeOrder[themeOrder.indexOf(currentTheme) + 1]
-    console.log('New theme:', newTheme)
 
     // 3 states are managed with a single variable. When theme is undefined, it means that the theme is managed by system preferences
     if(newTheme === 'system') {
-      console.log('@@device theme')
       localStorage.removeItem('theme')
-      console.log('@@device theme - localStorage:', localStorage)
     } else {
-      console.log('@@non device theme')
       localStorage.setItem('theme', newTheme)
     }
-    console.log('localStorage:', localStorage)
-
     updateTheme()
   })
-
-  console.log('@@INIT localStorage:', localStorage)
 
   // Required to ensure that the right theme for the 'highlight.js' library is used when the page loads
   updateTheme()

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -30,21 +30,10 @@
       {{/if}}
 
       <div class="theme-switch-wrapper">
-        <div class="toggle-content" id="theme-switcher">
-          <!--            TODO svg content may be store in a dedicated file and use in CSS-->
-          <!--            TODO configure dimensions in CSS?-->
-          <!--            TODO configure fill color in CSS?-->
-          <span class="theme-selector theme-selector-system" title="Switch to dark mode">
-             <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M396-396q-32-32-58.5-67T289-537q-5 14-6.5 28.5T281-480q0 83 58 141t141 58q14 0 28.5-2t28.5-6q-39-22-74-48.5T396-396Zm57-56q51 51 114 87.5T702-308q-40 51-98 79.5T481-200q-117 0-198.5-81.5T201-480q0-65 28.5-123t79.5-98q20 72 56.5 135T453-452Zm290 72q-20-5-39.5-11T665-405q8-18 11.5-36.5T680-480q0-83-58.5-141.5T480-680q-20 0-38.5 3.5T405-665q-8-19-13.5-38T381-742q24-9 49-13.5t51-4.5q117 0 198.5 81.5T761-480q0 26-4.5 51T743-380ZM440-840v-120h80v120h-80Zm0 840v-120h80V0h-80Zm323-706-57-57 85-84 57 56-85 85ZM169-113l-57-56 85-85 57 57-85 84Zm671-327v-80h120v80H840ZM0-440v-80h120v80H0Zm791 328-85-85 57-57 84 85-56 57ZM197-706l-84-85 56-57 85 85-57 57Zm199 310Z"/></svg>
-            </span>
-          <span class="theme-selector theme-selector-dark" title="Switch to light mode">
-              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M480-120q-150 0-255-105T120-480q0-150 105-255t255-105q14 0 27.5 1t26.5 3q-41 29-65.5 75.5T444-660q0 90 63 153t153 63q55 0 101-24.5t75-65.5q2 13 3 26.5t1 27.5q0 150-105 255T480-120Zm0-80q88 0 158-48.5T740-375q-20 5-40 8t-40 3q-123 0-209.5-86.5T364-660q0-20 3-40t8-40q-78 32-126.5 102T200-480q0 116 82 198t198 82Zm-10-270Z"/></svg>
-            </span>
-          <span class="theme-selector theme-selector-light" title="Switch to system preferences">
-<!--              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M440-760v-160h80v160h-80Zm266 110-55-55 112-115 56 57-113 113Zm54 210v-80h160v80H760ZM440-40v-160h80v160h-80ZM254-652 140-763l57-56 113 113-56 54Zm508 512L651-255l54-54 114 110-57 59ZM40-440v-80h160v80H40Zm157 300-56-57 112-112 29 27 29 28-114 114Zm283-100q-100 0-170-70t-70-170q0-100 70-170t170-70q100 0 170 70t70 170q0 100-70 170t-170 70Zm0-80q66 0 113-47t47-113q0-66-47-113t-113-47q-66 0-113 47t-47 113q0 66 47 113t113 47Zm0-160Z"/></svg>-->
-              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M440-800v-120h80v120h-80Zm0 760v-120h80v120h-80Zm360-400v-80h120v80H800Zm-760 0v-80h120v80H40Zm708-252-56-56 70-72 58 58-72 70ZM198-140l-58-58 72-70 56 56-70 72Zm564 0-70-72 56-56 72 70-58 58ZM212-692l-72-70 58-58 70 72-56 56Zm268 452q-100 0-170-70t-70-170q0-100 70-170t170-70q100 0 170 70t70 170q0 100-70 170t-170 70Zm0-80q67 0 113.5-46.5T640-480q0-67-46.5-113.5T480-640q-67 0-113.5 46.5T320-480q0 67 46.5 113.5T480-320Zm0-160Z"/></svg>
-<!--              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M480-360q50 0 85-35t35-85q0-50-35-85t-85-35q-50 0-85 35t-35 85q0 50 35 85t85 35Zm0 80q-83 0-141.5-58.5T280-480q0-83 58.5-141.5T480-680q83 0 141.5 58.5T680-480q0 83-58.5 141.5T480-280ZM200-440H40v-80h160v80Zm720 0H760v-80h160v80ZM440-760v-160h80v160h-80Zm0 720v-160h80v160h-80ZM256-650l-101-97 57-59 96 100-52 56Zm492 496-97-101 53-55 101 97-57 59Zm-98-550 97-101 59 57-100 96-56-52ZM154-212l101-97 55 53-97 101-59-57Zm326-268Z"/></svg>-->
-            </span>
+        <div class="theme-switch-container" id="theme-switcher">
+          <span class="theme-selector theme-selector-system" title="Switch to dark mode"></span>
+          <span class="theme-selector theme-selector-dark" title="Switch to light mode"></span>
+          <span class="theme-selector theme-selector-light" title="Switch to system preferences"></span>
         </div>
       </div>
 

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -30,13 +30,21 @@
       {{/if}}
 
       <div class="theme-switch-wrapper">
-        <input type="checkbox" class="checkbox" id="theme-switch">
-        <div class="toggle-content">
-          <label class="label" for="theme-switch">
-            <span>🌜</span>
-            <span>🌞</span>
-            <div class="ball"></div>
-          </label>
+        <div class="toggle-content" id="theme-switcher">
+          <!--            TODO svg content may be store in a dedicated file and use in CSS-->
+          <!--            TODO configure dimensions in CSS?-->
+          <!--            TODO configure fill color in CSS?-->
+          <span class="theme-selector theme-selector-system" title="Switch to dark mode">
+             <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M396-396q-32-32-58.5-67T289-537q-5 14-6.5 28.5T281-480q0 83 58 141t141 58q14 0 28.5-2t28.5-6q-39-22-74-48.5T396-396Zm57-56q51 51 114 87.5T702-308q-40 51-98 79.5T481-200q-117 0-198.5-81.5T201-480q0-65 28.5-123t79.5-98q20 72 56.5 135T453-452Zm290 72q-20-5-39.5-11T665-405q8-18 11.5-36.5T680-480q0-83-58.5-141.5T480-680q-20 0-38.5 3.5T405-665q-8-19-13.5-38T381-742q24-9 49-13.5t51-4.5q117 0 198.5 81.5T761-480q0 26-4.5 51T743-380ZM440-840v-120h80v120h-80Zm0 840v-120h80V0h-80Zm323-706-57-57 85-84 57 56-85 85ZM169-113l-57-56 85-85 57 57-85 84Zm671-327v-80h120v80H840ZM0-440v-80h120v80H0Zm791 328-85-85 57-57 84 85-56 57ZM197-706l-84-85 56-57 85 85-57 57Zm199 310Z"/></svg>
+            </span>
+          <span class="theme-selector theme-selector-dark" title="Switch to light mode">
+              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M480-120q-150 0-255-105T120-480q0-150 105-255t255-105q14 0 27.5 1t26.5 3q-41 29-65.5 75.5T444-660q0 90 63 153t153 63q55 0 101-24.5t75-65.5q2 13 3 26.5t1 27.5q0 150-105 255T480-120Zm0-80q88 0 158-48.5T740-375q-20 5-40 8t-40 3q-123 0-209.5-86.5T364-660q0-20 3-40t8-40q-78 32-126.5 102T200-480q0 116 82 198t198 82Zm-10-270Z"/></svg>
+            </span>
+          <span class="theme-selector theme-selector-light" title="Switch to system preferences">
+<!--              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M440-760v-160h80v160h-80Zm266 110-55-55 112-115 56 57-113 113Zm54 210v-80h160v80H760ZM440-40v-160h80v160h-80ZM254-652 140-763l57-56 113 113-56 54Zm508 512L651-255l54-54 114 110-57 59ZM40-440v-80h160v80H40Zm157 300-56-57 112-112 29 27 29 28-114 114Zm283-100q-100 0-170-70t-70-170q0-100 70-170t170-70q100 0 170 70t70 170q0 100-70 170t-170 70Zm0-80q66 0 113-47t47-113q0-66-47-113t-113-47q-66 0-113 47t-47 113q0 66 47 113t113 47Zm0-160Z"/></svg>-->
+              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M440-800v-120h80v120h-80Zm0 760v-120h80v120h-80Zm360-400v-80h120v80H800Zm-760 0v-80h120v80H40Zm708-252-56-56 70-72 58 58-72 70ZM198-140l-58-58 72-70 56 56-70 72Zm564 0-70-72 56-56 72 70-58 58ZM212-692l-72-70 58-58 70 72-56 56Zm268 452q-100 0-170-70t-70-170q0-100 70-170t170-70q100 0 170 70t70 170q0 100-70 170t-170 70Zm0-80q67 0 113.5-46.5T640-480q0-67-46.5-113.5T480-640q-67 0-113.5 46.5T320-480q0 67 46.5 113.5T480-320Zm0-160Z"/></svg>
+<!--              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M480-360q50 0 85-35t35-85q0-50-35-85t-85-35q-50 0-85 35t-35 85q0 50 35 85t85 35Zm0 80q-83 0-141.5-58.5T280-480q0-83 58.5-141.5T480-680q83 0 141.5 58.5T680-480q0 83-58.5 141.5T480-280ZM200-440H40v-80h160v80Zm720 0H760v-80h160v80ZM440-760v-160h80v160h-80Zm0 720v-160h80v160h-80ZM256-650l-101-97 57-59 96 100-52 56Zm492 496-97-101 53-55 101 97-57 59Zm-98-550 97-101 59 57-100 96-56-52ZM154-212l101-97 55 53-97 101-59-57Zm326-268Z"/></svg>-->
+            </span>
         </div>
       </div>
 

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -188,7 +188,7 @@ body {
 }
 
 /**************************
-********* TOGGLE **********
+********* TOGGLE THEME ****
 ***************************/
 
 .theme-switch-wrapper {
@@ -204,61 +204,38 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.3s ease;
-}
+  //transition: background 0.1s ease; // TODO check if this is necessary
 
-.checkbox {
-  display: none;
-}
-
-.label {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   position: relative;
   background: var(--color-blue-bonita);
-  border: 2px solid var(--color-focused);
   opacity: 0.85;
   border-radius: 5rem;
-  padding: 0.5rem 0.5rem 0.5rem 0.3rem;
-  height: 1.8rem;
-  width: 3.8rem;
+  height: 2.2rem;
+  width: 2.2rem;
   font-size: 0.9rem;
-  transition: background 0.5s ease;
   cursor: pointer;
-  z-index: 1;
 
   &:hover {
     opacity: 1;
-
-    .ball {
-      box-shadow: 0 0 5px 3px var(--color-blue-bright);
-    }
-  }
-}
-
-.label .ball {
-  position: absolute;
-  background-color: var(--color-focused);
-  border-radius: 50%;
-  left: 0.25rem;
-  height: 1.3rem;
-  width: 1.3rem;
-  transform: translateX(0);
-
-  &:hover {
+    //background-color: var(--color-focused); // TODO find the right color
     box-shadow: 0 0 5px 3px var(--color-blue-bright);
   }
 }
 
-.checkbox:checked + .toggle-content .label .ball {
-  transform: translateX(1.7rem);
+// TODO svg fill color candidate var(--color-focused)
+.theme-selector {
+  display: none;
 }
 
-.checkbox:checked + .toggle-content {
-  --dark-opacity: 1;
-  --light-opacity: 0;
+html[data-theme-system="true"] .theme-selector-system {
+  display: block;
 }
+
+html[data-theme-system="false"][data-theme="dark"] .theme-selector-dark,
+html[data-theme-system="false"][data-theme="light"] .theme-selector-light {
+  display: block;
+}
+
 
 /**************************
 ****** Media Queries ******

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -198,16 +198,14 @@ body {
   padding: 0.5rem;
 }
 
-.toggle-content {
+.theme-switch-container {
   background-color: transparent;
   color: var(--navbar-menu-font-color);
   display: flex;
   align-items: center;
   justify-content: center;
-  //transition: background 0.1s ease; // TODO check if this is necessary
 
   position: relative;
-  background: var(--color-blue-bonita);
   opacity: 0.85;
   border-radius: 5rem;
   height: 2.2rem;
@@ -217,23 +215,33 @@ body {
 
   &:hover {
     opacity: 1;
-    //background-color: var(--color-focused); // TODO find the right color
     box-shadow: 0 0 5px 3px var(--color-blue-bright);
   }
 }
 
-// TODO svg fill color candidate var(--color-focused)
 .theme-selector {
   display: none;
+  width: 70%;
+  height: 70%;
+  background-color: var(--navbar-unfocused-font-color);
 }
 
 html[data-theme-system="true"] .theme-selector-system {
   display: block;
+  // based on https://fonts.google.com/icons?icon.query=routine&icon.set=Material+Symbols&selected=Material+Symbols+Outlined:routine:FILL@0;wght@400;GRAD@0;opsz@24&icon.size=24&icon.color=%23e8eaed
+  mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M396-396q-32-32-58.5-67T289-537q-5 14-6.5 28.5T281-480q0 83 58 141t141 58q14 0 28.5-2t28.5-6q-39-22-74-48.5T396-396Zm57-56q51 51 114 87.5T702-308q-40 51-98 79.5T481-200q-117 0-198.5-81.5T201-480q0-65 28.5-123t79.5-98q20 72 56.5 135T453-452Zm290 72q-20-5-39.5-11T665-405q8-18 11.5-36.5T680-480q0-83-58.5-141.5T480-680q-20 0-38.5 3.5T405-665q-8-19-13.5-38T381-742q24-9 49-13.5t51-4.5q117 0 198.5 81.5T761-480q0 26-4.5 51T743-380ZM440-840v-120h80v120h-80Zm0 840v-120h80V0h-80Zm323-706-57-57 85-84 57 56-85 85ZM169-113l-57-56 85-85 57 57-85 84Zm671-327v-80h120v80H840ZM0-440v-80h120v80H0Zm791 328-85-85 57-57 84 85-56 57ZM197-706l-84-85 56-57 85 85-57 57Zm199 310Z"/></svg>') no-repeat center / contain;
 }
 
-html[data-theme-system="false"][data-theme="dark"] .theme-selector-dark,
+html[data-theme-system="false"][data-theme="dark"] .theme-selector-dark  {
+  display: block;
+  // based on https://fonts.google.com/icons?icon.query=dark&icon.set=Material+Symbols&selected=Material+Symbols+Outlined:dark_mode:FILL@0;wght@400;GRAD@0;opsz@24&icon.size=24&icon.color=%23e8eaed
+  mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M480-120q-150 0-255-105T120-480q0-150 105-255t255-105q14 0 27.5 1t26.5 3q-41 29-65.5 75.5T444-660q0 90 63 153t153 63q55 0 101-24.5t75-65.5q2 13 3 26.5t1 27.5q0 150-105 255T480-120Zm0-80q88 0 158-48.5T740-375q-20 5-40 8t-40 3q-123 0-209.5-86.5T364-660q0-20 3-40t8-40q-78 32-126.5 102T200-480q0 116 82 198t198 82Zm-10-270Z"/></svg>') no-repeat center / contain;
+}
+
 html[data-theme-system="false"][data-theme="light"] .theme-selector-light {
   display: block;
+  // based on https://fonts.google.com/icons?icon.query=sunny&icon.set=Material+Symbols&selected=Material+Symbols+Outlined:wb_sunny:FILL@0;wght@400;GRAD@0;opsz@24&icon.size=24&icon.color=%23e8eaed
+  mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M440-800v-120h80v120h-80Zm0 760v-120h80v120h-80Zm360-400v-80h120v80H800Zm-760 0v-80h120v80H40Zm708-252-56-56 70-72 58 58-72 70ZM198-140l-58-58 72-70 56 56-70 72Zm564 0-70-72 56-56 72 70-58 58ZM212-692l-72-70 58-58 70 72-56 56Zm268 452q-100 0-170-70t-70-170q0-100 70-170t170-70q100 0 170 70t70 170q0 100-70 170t-170 70Zm0-80q67 0 113.5-46.5T640-480q0-67-46.5-113.5T480-640q-67 0-113.5 46.5T320-480q0 67 46.5 113.5T480-320Zm0-160Z"/></svg>') no-repeat center / contain;
 }
 
 


### PR DESCRIPTION
Previously, there were only 2 states for the theme selector: dark or light. If the user didn't touch the theme selector, the system preferences were used without they know it. Once they use the theme selector, it was no longer possible to use the system preferences.

This is now possible to choose to use the theme based on the system preferences. The ball selector has been replaced by an icon rolling, so only the current state of the theme selection is displayed. The icons are taken from Material Symbols.


## Notes

Closes #231 

**Remaining Tasks**

- [x] remove the console log
- [x] manage TODO
- [x] validate the "light" icon
- [x] tests on various browsers: Chrome 133.0.6943.53 (official Build) (64 bits) and Firefox 135.0 (64 bits) on Ubuntu 22.04
- [x] check the mobile view
- [x] review the CSS rules (check if the SCSS syntax can simplify)
- [x] define the icon in the CSS file (prevent duplication in all pages by loading it only once with the CSS file)
- [x] Add video before and after the changes
- [x] Fix build and SonarQube errors

## Videos

### Previous implementation

[PR_242_01_before_change.webm](https://github.com/user-attachments/assets/726a30ea-edd3-4380-add8-756c2b9d43bb)

### New implementation with prefers-color-scheme dark

[PR_242_02_after_change_default_dark.webm](https://github.com/user-attachments/assets/15502821-501e-4481-8851-18b18aefe33f)

### New implementation with prefers-color-scheme light

[PR_242_02_after_change_default_light.webm](https://github.com/user-attachments/assets/b6d189f2-38d6-42b0-9756-84425f5a1954)


