### PR TITLE
feat: make the theme switcher more accessible

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -30,11 +30,11 @@
       {{/if}}
 
       <div class="theme-switch-wrapper">
-        <div class="theme-switch-container" id="theme-switcher">
+        <button class="theme-switch-container" id="theme-switcher" aria-label="Theme switcher" aria-pressed="false" role="switch">
           <span class="theme-selector theme-selector-system" title="Switch to dark mode"></span>
           <span class="theme-selector theme-selector-dark" title="Switch to light mode"></span>
           <span class="theme-selector theme-selector-light" title="Switch to system preferences"></span>
-        </div>
+        </button>
       </div>
 
       <button class="navbar-burger" data-target="topbar-nav-mobile">

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -210,10 +210,11 @@ body {
   border-radius: 5rem;
   height: 2.2rem;
   width: 2.2rem;
-  font-size: 0.9rem;
+  border-width: 0;
+  padding: 0;
   cursor: pointer;
 
-  &:hover {
+  &:hover, &:focus {
     opacity: 1;
     box-shadow: 0 0 5px 3px var(--color-blue-bright);
   }


### PR DESCRIPTION
It is now focusable and declare aria attributes to improve accessibility.

### In action

### Before (on Firefox)

[01_before_on_firefox.webm](https://github.com/user-attachments/assets/0f5d56e2-1251-4aa6-9756-4c3fd0b0071f)

### Now (on Chrome)

[02_PR_243_on_chrome.webm](https://github.com/user-attachments/assets/9c48664f-864f-4c82-9864-f84ae00f4efa)

