### PR TITLE
feat: improve the dark mode for asciidoctor-tabs and highlight.js

### DIFF
--- a/src/stylesheets/components/asciidoc-tabs-dark.scss
+++ b/src/stylesheets/components/asciidoc-tabs-dark.scss
@@ -1,0 +1,23 @@
+// This is a custom override for the AsciiDoc tabs component which does not provide rules for dark mode in version 1.0.0-beta.6
+
+html[data-theme="dark"] {
+  .tabs {
+    .tablist li {
+      &.is-selected,
+      &.is-selected::after {
+        background-color: var(--color-smoke-90);
+        border-color: var(--color-smoke-90);
+      }
+
+      &:not(.is-selected) {
+        border-color: var(--color-smoke-50);
+        background-color: var(--color-smoke-50);
+      }
+    }
+
+    .tabpanel {
+      background-color: var(--color-smoke-90);
+      border-color: var(--color-smoke-90);
+    }
+  }
+}

--- a/src/stylesheets/doc.scss
+++ b/src/stylesheets/doc.scss
@@ -1193,7 +1193,7 @@
 
   pre.highlight {
     code {
-      background: var(--pre-background);
+      background: var(--code-background);
       box-shadow: inset 0 0 1.75px var(--pre-border-color);
       display: block;
       overflow-x: auto;

--- a/src/stylesheets/globals/vars.scss
+++ b/src/stylesheets/globals/vars.scss
@@ -47,7 +47,7 @@
   --color-higlight-link: #005889;
   --color-footer: #e6e6e6;
   --color-card-border: #ebf2f2;
-  --color-code-background: #f9f2f4;
+  --color-code-background: var(--pre-background);
   --color-code-font: #c7254e;
   --color-troubleshooting-border: var(--color-admonition-important-bg);
   --color-pagination-border: #dadde1;

--- a/src/stylesheets/site.scss
+++ b/src/stylesheets/site.scss
@@ -18,3 +18,4 @@
 @import "search.scss";
 @import "components/troubleshooting.scss";
 @import "components/colors.scss";
+@import "components/asciidoc-tabs-dark.scss";


### PR DESCRIPTION
asciidoctor-tabs doesn't provide CSS for dark mode, so add new CSS rules to support it.
Adjust highlight.js background color for code blocks.


## Screenshots

### asciidoctor-tabs

before | now
---- | ----
![Screenshot 2025-02-19 at 15-17-06 Tabs block Bonita Documentation Theme Preview](https://github.com/user-attachments/assets/67e43c9e-5169-4467-8627-0ce7276c720a) | ![Screenshot 2025-02-19 at 15-16-55 Tabs block Bonita Documentation Theme Preview](https://github.com/user-attachments/assets/50bdb0bf-9888-4f17-b8b0-73112c6c2255)



### hightlight.js

before | now
---- | ----
 |
