### PR TITLE
feat: clarify the tooltip of the theme button

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -39,9 +39,9 @@
 
       <div class="theme-switch-wrapper">
         <button class="theme-switch-container" id="theme-switcher" aria-label="Theme switcher" aria-pressed="false" role="switch">
-          <span class="theme-selector theme-selector-system" title="Switch to dark mode"></span>
-          <span class="theme-selector theme-selector-dark" title="Switch to light mode"></span>
-          <span class="theme-selector theme-selector-light" title="Switch to system preferences"></span>
+          <span class="theme-selector theme-selector-system" title="System mode"></span>
+          <span class="theme-selector theme-selector-dark" title="Dark mode"></span>
+          <span class="theme-selector theme-selector-light" title="Light mode"></span>
         </button>
       </div>
 


### PR DESCRIPTION
Previously, the tooltip displayed the action that will be done when clicking on the button.
This was unclear for the users.
Now, the tooltip displays the name of the theme currently in use.